### PR TITLE
Support a default value for DbString.IsAnsi

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -2949,10 +2949,34 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
     /// </summary>
     sealed partial class DbString
     {
+        static DbString()
+        {
+            DefaultStringDbType = DbType.String;
+        }
+
+        private static DbType _defaultStringDbType;
+        /// <summary>
+        /// Default value for IsAnsi. Set to either DbType.String (the default) or DbType.AnsiString.
+        /// </summary>
+        public static DbType DefaultStringDbType
+        {
+            get { return _defaultStringDbType; }
+            set
+            {
+                if (value != DbType.AnsiString && value != DbType.String)
+                    throw new ArgumentException("Invalid value. Must be either DbType.AnsiString or DbType.String");
+                _defaultStringDbType = value;
+            }
+        }
+
         /// <summary>
         /// Create a new DbString
         /// </summary>
-        public DbString() { Length = -1; }
+        public DbString()
+        {
+            Length = -1;
+            IsAnsi = DefaultStringDbType == DbType.AnsiString;
+        }
         /// <summary>
         /// Ansi vs Unicode 
         /// </summary>

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -1112,6 +1112,35 @@ end");
             ((int)obj.f).IsEqualTo(10);
         }
 
+        public void TestDefaultDbStringDbType()
+        {
+            var origDefaultStringDbType = DbString.DefaultStringDbType;
+            try
+            {
+                DbString.DefaultStringDbType = DbType.AnsiString;
+                var a = new DbString { Value = "abcde" };
+                var b = new DbString { Value = "abcde", IsAnsi = false };
+                a.IsAnsi.IsTrue();
+                b.IsAnsi.IsFalse();
+
+                var exceptionThrow = false;
+                try
+                {
+                    DbString.DefaultStringDbType = DbType.Int32;
+                }
+                catch
+                {
+                    exceptionThrow = true;
+                }
+                exceptionThrow.IsTrue();
+                
+            }
+            finally
+            {
+                DbString.DefaultStringDbType = origDefaultStringDbType;
+            }
+        }
+
         class Person
         {
             public int PersonId { get; set; }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -1123,16 +1123,16 @@ end");
                 a.IsAnsi.IsTrue();
                 b.IsAnsi.IsFalse();
 
-                var exceptionThrow = false;
+                var exceptionThrown = false;
                 try
                 {
                     DbString.DefaultStringDbType = DbType.Int32;
                 }
                 catch
                 {
-                    exceptionThrow = true;
+                    exceptionThrown = true;
                 }
-                exceptionThrow.IsTrue();
+                exceptionThrown.IsTrue();
                 
             }
             finally


### PR DESCRIPTION
It is painful and easy to forget to set `DbString.IsAnsi = true` when dealing with databases that mainly use char/varchar data types (as opposed to nchar/nvarchar).

This patch allows a default value for `DbString.IsAnsi` to be configured via the `DefaultStringDbType` static property.