### PR TITLE
Table reflection does not work for table with Id that is not int

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -19,18 +19,28 @@ using System.Reflection.Emit;
 namespace Dapper
 {
     /// <summary>
+    /// A container for a database, assumes all the tables have an Id column of type int named Id
+    /// </summary>
+    /// <typeparam name="TDatabase">The Dapper.Database implementation type</typeparam>
+    public abstract class Database<TDatabase> : Database<TDatabase, int>
+        where TDatabase : Database<TDatabase>, new()
+    { }
+
+
+    /// <summary>
     /// A container for a database, assumes all the tables have an Id column named Id
     /// </summary>
-    /// <typeparam name="TDatabase"></typeparam>
-    public abstract class Database<TDatabase> : IDisposable where TDatabase : Database<TDatabase>, new()
+    /// <typeparam name="TDatabase">The Dapper.Database implementation type</typeparam>
+    /// <typeparam name="TId">The table primary key Id type</typeparam>
+    public abstract class Database<TDatabase, TId> : IDisposable where TDatabase : Database<TDatabase, TId>, new()
     {
-        public class Table<T, TId>
+        public class Table<T>
         {
-            internal Database<TDatabase> database;
+            internal Database<TDatabase, TId> database;
             internal string tableName;
             internal string likelyTableName;
 
-            public Table(Database<TDatabase> database, string likelyTableName)
+            public Table(Database<TDatabase, TId> database, string likelyTableName)
             {
                 this.database = database;
                 this.likelyTableName = likelyTableName;
@@ -136,13 +146,6 @@ namespace Dapper
                 return paramNames;
             }
         }
-
-		public class Table<T> : Table<T, int> {
-			public Table(Database<TDatabase> database, string likelyTableName)
-				: base(database, likelyTableName)
-			{
-			}
-		}
 
         DbConnection connection;
         int commandTimeout;


### PR DESCRIPTION
The problem originated from trying to use Activator on typeof(Table<>) instead of typeof(Table<,>) e.g. for Table<Product, Guid>.

However, since table construction is handled the same for all tables in a database, I pulled the Table Id generic typing from the Table class and put it into the Database class. The idea is to specify Id typing once in the Database instead of in each Table.

I also added a Database implementation that assumes Id=typeof(int) to prevent breaking existing usage. I don't think Table was working with non-int Ids before this, so these changes should not negatively affect that use case.

Maybe the ideal situation would be to examine each Table property in the Database, and use Activator directly on its GetType().GetGenericTypeDefinition(). Though this might be a bit of an overhaul and might affect performance.

DapperTests all passed, and I successfully tested Tables of type int and Guid. Hope this is helpful.