### PR TITLE
Added optional property ignore during insert.

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -50,11 +50,24 @@ namespace Dapper
             /// </summary>
             /// <param name="data">Either DynamicParameters or an anonymous type or concrete type</param>
             /// <returns></returns>
-            public virtual int? Insert(dynamic data)
+            public virtual int? Insert(dynamic data, params string[] ignore)
             {
                 var o = (object)data;
                 List<string> paramNames = GetParamNames(o);
-                paramNames.Remove("Id");
+				
+				if (ignore.Length > 0)
+				{
+					paramNames = new List<string>();
+					foreach (var prop in o.GetType().GetProperties(BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public))
+					{
+						paramNames.Add(prop.Name);
+					}
+
+					foreach (var field in ignore)
+					{
+						paramNames.Remove(field);
+					}
+				}
 
                 string cols = string.Join(",", paramNames);
                 string cols_params = string.Join(",", paramNames.Select(p => "@" + p));

--- a/Dapper.Rainbow/SqlCompactDatabase.cs
+++ b/Dapper.Rainbow/SqlCompactDatabase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Reflection;
 
 namespace Dapper.Rainbow
 {
@@ -19,11 +20,24 @@ namespace Dapper.Rainbow
             /// </summary>
             /// <param name="data">Either DynamicParameters or an anonymous type or concrete type</param>
             /// <returns></returns>
-            public override int? Insert(dynamic data)
+            public override int? Insert(dynamic data, params string[] ignore)
             {
                 var o = (object)data;
                 List<string> paramNames = GetParamNames(o);
-                paramNames.Remove("Id");
+				
+				if (ignore.Length > 0)
+				{
+					paramNames = new List<string>();
+					foreach (var prop in o.GetType().GetProperties(BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.Public))
+					{
+						paramNames.Add(prop.Name);
+					}
+
+					foreach (var field in ignore)
+					{
+						paramNames.Remove(field);
+					}
+				}
 
                 string cols = string.Join(",", paramNames);
                 string cols_params = string.Join(",", paramNames.Select(p => "@" + p));


### PR DESCRIPTION
Regarding pull request #66.  I agree that Id should not always be removed.  This will allow for an optional id column, as well as any other column for that matter.  It ignores the cache, if there exists some prop to ignore.