### PR TITLE
Simple Func to allow provision of TypeMaps automatically

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -2157,6 +2157,12 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
         /// <summary>
         /// Gets type-map for the given type
         /// </summary>
+        /// <returns>Type map instance, default is to create new instance of DefaultTypeMap</returns>
+        public static Func<Type, ITypeMap> TypeMapProvider = ( Type type ) => new DefaultTypeMap( type );
+
+        /// <summary>
+        /// Gets type-map for the given type
+        /// </summary>
         /// <returns>Type map implementation, DefaultTypeMap instance if no override present</returns>
         public static ITypeMap GetTypeMap(Type type)
         {
@@ -2170,7 +2176,7 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
                     map = (ITypeMap)_typeMaps[type];
                     if (map == null)
                     {
-                        map = new DefaultTypeMap(type);
+                        map = TypeMapProvider( type );
                         _typeMaps[type] = map;
                     }
                 }


### PR DESCRIPTION
Provision of a TypeMapProvider property to allow lazy creation of type maps only when they are needed

The Func simply returns a new DefaultTypeMap instance by default but you can replace the Func with something more useful - for example I am using a custom class that implements ITypeMap that uses the DataAnnotations attributes for column names.

