### PR TITLE
Added ExecuteWithOutput method

### DIFF
--- a/Dapper NET45/SqlMapperAsync.cs
+++ b/Dapper NET45/SqlMapperAsync.cs
@@ -176,23 +176,5 @@ namespace Dapper
                 return buffered ? results.ToList() : results;
             }
         }
-
-        private static IEnumerable<T> ExecuteReader<T>(IDataReader reader, Identity identity, CacheInfo info)
-        {
-            var tuple = info.Deserializer;
-            int hash = GetColumnHash(reader);
-            if (tuple.Func == null || tuple.Hash != hash)
-            {
-                tuple = info.Deserializer = new DeserializerState(hash, GetDeserializer(typeof(T), reader, 0, -1, false));
-                SetQueryCache(identity, info);
-            }
-
-            var func = tuple.Func;
-
-            while (reader.Read())
-            {
-                yield return (T)func(reader);
-            }
-        }
     }
 }


### PR DESCRIPTION
I ran into a situation recently where I need to retrieve more than just the ID of the new row that was created, and I wanted to add code that would behave the same as the existing `Execute()` method when provided with an `IEnumerable` parameter.

I noted that the `TestSplitWithMissingMembers()` test is failing, but I did not touch that code, so I assume it's either something specific to my environment or would also be failing in master.