### PR TITLE
FIX: Properties of type Table<T, TId> are not initialized

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -177,7 +177,7 @@ namespace Dapper
 
         internal virtual Action<TDatabase> CreateTableConstructorForTable()
         {
-            return CreateTableConstructor(typeof(Table<>));
+            return CreateTableConstructor(typeof(Table<>), typeof(Table<,>));
         }
 
         public void BeginTransaction(IsolationLevel isolation = IsolationLevel.ReadCommitted)
@@ -197,13 +197,13 @@ namespace Dapper
             transaction = null;
         }
 
-        protected Action<TDatabase> CreateTableConstructor(Type tableType)
+        protected Action<TDatabase> CreateTableConstructor(params Type[] tableTypes)
         {
             var dm = new DynamicMethod("ConstructInstances", null, new Type[] { typeof(TDatabase) }, true);
             var il = dm.GetILGenerator();
 
             var setters = GetType().GetProperties()
-                .Where(p => p.PropertyType.IsGenericType && p.PropertyType.GetGenericTypeDefinition() == tableType)
+                .Where(p => p.PropertyType.IsGenericType && tableTypes.Contains(p.PropertyType.GetGenericTypeDefinition()))
                 .Select(p => Tuple.Create(
                         p.GetSetMethod(true),
                         p.PropertyType.GetConstructor(new Type[] { typeof(TDatabase), typeof(string) }),


### PR DESCRIPTION
Table properties that implement ```Table<T,TId>``` instead of ```Table<T>``` are not recognized during the initialization of the ```Database<T>``` class. As a result, these properties remain uninitialized after the call to ```Database<T>.Init()```.

```
// Works fine
public Table<Person> Persons { get; set; }

// Remains 'null' after Init
public Table<Car, Guid> Cars { get; set; }
```