### PR TITLE
Always use TypeHandler for parameters if available

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -849,7 +849,7 @@ namespace Dapper
         internal static DbType LookupDbType(Type type, string name, out ITypeHandler handler)
         {
             DbType dbType;
-            handler = null;
+            typeHandlers.TryGetValue(type, out handler);
             var nullUnderlyingType = Nullable.GetUnderlyingType(type);
             if (nullUnderlyingType != null) type = nullUnderlyingType;
             if (type.IsEnum && !typeMap.ContainsKey(type))
@@ -869,7 +869,7 @@ namespace Dapper
                 return DynamicParameters.EnumerableMultiParameter;
             }
 
-            if (typeHandlers.TryGetValue(type, out handler))
+            if (handler != null)
             {
                 return DbType.Object;
             }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -3851,6 +3851,84 @@ SELECT value FROM @table WHERE value IN @myIds";
 
             connection.Query("SELECT @param1", parameters);
         }
+
+        public void TypeHandlerSetValueCalledForBuiltInSqlTypes()
+        {
+            // Commented out tests are for types that aren't directly supported by SqlDbType
+
+            TypeHandlerSetValueCalledForBuiltInSqlType<byte>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<sbyte>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<short>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<ushort>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<int>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<uint>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<long>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<ulong>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<float>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<double>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<decimal>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<bool>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<string>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<char>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<Guid>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<DateTime>((DateTime)SqlDateTime.MinValue);
+            TypeHandlerSetValueCalledForBuiltInSqlType<DateTimeOffset>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<TimeSpan>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<byte[]>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<byte?>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<sbyte?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<short?>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<ushort?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<int?>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<uint?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<long?>();
+            //TypeHandlerSetValueCalledForBuiltInSqlType<ulong?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<float?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<double?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<decimal?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<bool?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<char?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<Guid?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<DateTime?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<DateTimeOffset?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<TimeSpan?>();
+            TypeHandlerSetValueCalledForBuiltInSqlType<object>();
+        }
+
+        private void TypeHandlerSetValueCalledForBuiltInSqlType<T>(T testValue = default(T))
+        {
+            Dapper.SqlMapper.ResetTypeHandlers();
+
+            var handler = new TypeHandlerSetValueCalledHandler();
+            
+            // Test that logic still works without handler
+            connection.Query("SELECT @param", new { param = testValue });
+
+            // Now try with handler overriding default logic
+            Dapper.SqlMapper.AddTypeHandler(typeof(T), handler);
+            connection.Query("SELECT @param1", new { param1 = testValue });
+
+            Dapper.SqlMapper.ResetTypeHandlers();
+
+            handler.WasSet.IsTrue();
+        }
+
+        public class TypeHandlerSetValueCalledHandler : Dapper.SqlMapper.ITypeHandler
+        {
+            public bool WasSet = false;
+
+            public object Parse(Type destinationType, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetValue(IDbDataParameter parameter, object value)
+            {
+                WasSet = true;
+                parameter.Value = value;
+            }
+        }
+
 #if POSTGRESQL
 
         class Cat


### PR DESCRIPTION
Previously TypeHandlers could override the logic for built-in SQL data
types (int, byte, DateTime, etc.) when they were return values via
ITypeHandler.Parse, but ITypeHandler.SetValue was never called for these
types when used as parameters. Moved the typeHandlers.TryGetValue() call
up to make sure a type handler is always used if available.

Added tests to confirm standard behaviour is still working, and that ITypeHandler.SetValue is now called for built-in types.