### PR TITLE
Properties of type Table<TDatabase, TId> results in a null value after Database.Init

### DIFF
--- a/Dapper.Rainbow/Database.cs
+++ b/Dapper.Rainbow/Database.cs
@@ -177,7 +177,7 @@ namespace Dapper
 
         internal virtual Action<TDatabase> CreateTableConstructorForTable()
         {
-            return CreateTableConstructor(typeof(Table<>));
+            return CreateTableConstructor(typeof (Table<>), typeof (Table<,>));
         }
 
         public void BeginTransaction(IsolationLevel isolation = IsolationLevel.ReadCommitted)
@@ -197,13 +197,18 @@ namespace Dapper
             transaction = null;
         }
 
-        protected Action<TDatabase> CreateTableConstructor(Type tableType)
+        protected Action<TDatabase> CreateTableConstructor(params Type[] tableType)
+        {
+            return CreateTableConstructor(tableType.ToList());
+        }
+
+        protected Action<TDatabase> CreateTableConstructor(List<Type> tableTypes)
         {
             var dm = new DynamicMethod("ConstructInstances", null, new Type[] { typeof(TDatabase) }, true);
             var il = dm.GetILGenerator();
 
             var setters = GetType().GetProperties()
-                .Where(p => p.PropertyType.IsGenericType && p.PropertyType.GetGenericTypeDefinition() == tableType)
+                .Where(p => p.PropertyType.IsGenericType && tableTypes.Contains(p.PropertyType.GetGenericTypeDefinition()))
                 .Select(p => Tuple.Create(
                         p.GetSetMethod(true),
                         p.PropertyType.GetConstructor(new Type[] { typeof(TDatabase), typeof(string) }),


### PR DESCRIPTION
For Dapper.Rainbow, declaring a property as Table<TDatabase, TId> will result in a null value for the property after calling Database.Init because the method to generate the constructor does not account for the type Table<,>. This pull request fixes that problem.

The workaround for this bug would be to subclass Table like "StringTable : Table<TDatabase, string>" and then declare the properties as StringTable versus Table<TDatabase, string>.