### PR TITLE
Adding support for f# record types containing enums (and other classes with an explicit constructor defined)

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -5265,7 +5265,8 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
                     var unboxedType = Nullable.GetUnderlyingType(ctorParameters[i].ParameterType) ?? ctorParameters[i].ParameterType;
                     if (unboxedType != types[i]
                         && !(unboxedType.IsEnum && Enum.GetUnderlyingType(unboxedType) == types[i])
-                        && !(unboxedType == typeof(char) && types[i] == typeof(string)))
+                        && !(unboxedType == typeof(char) && types[i] == typeof(string))
+                        && !(unboxedType.IsEnum && types[i] == typeof(string)))
                         break;
                 }
 

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -3496,6 +3496,25 @@ option (optimize for (@vals unKnoWn))";
             foo.CategoryRating.Value.IsEqualTo(200);
         }
 
+        enum SO27024806Enum { Foo, Bar }
+
+        private class SO27024806Class
+        {
+            public SO27024806Class(SO27024806Enum myField)
+            {
+                this.MyField = myField;
+            }
+
+            public SO27024806Enum MyField { get; set; }
+        }
+
+        public void SO27024806_TestVarcharEnumMemberWithExplicitConstructor()
+        {
+            var foo = connection.Query<SO27024806Class>("SELECT 'Foo' AS myField").Single();
+            foo.MyField.IsEqualTo(SO27024806Enum.Foo);
+        }
+
+
         public void SO24740733_TestCustomValueSingleColumn()
         {
             Dapper.SqlMapper.AddTypeHandler(RatingValueHandler.Default);

--- a/dapper.nuspec
+++ b/dapper.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata schemaVersion="2">
     <id>Dapper</id>
-    <version>1.38</version>
-    <title>Dapper dot net</title>
+    <version>2.0</version>
+    <title>Dapper dot net rfq</title>
     <authors>Sam Saffron,Marc Gravell</authors>
     <owners>Sam Saffron,Marc Gravell</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>


### PR DESCRIPTION
The main issue I'm trying to solve is that you can't use Dapper on f# records if they have some enum members stored as varchar in the database. 

f# records have a single strongly typed constructor, and in the current master branch this strongly typed constructor is discarded by Dapper on the grounds that enum and string are not compatible types.

It's not so much an issue in c# because you can always define an appropriate constructors, but f# doesn't let you define any constructors.

I have added a unit test to describe the failing scenario (also described on stack overflow : SO27024806)

The change is a single-line changed in FindConstructor. I believe the performance impact is probably negligible. It's true we might end up with exceptions thrown if the value stored in the database can't be parsed as an enum, but that's consistent with how dapper handles enums stored in database as their base types.

