### PR TITLE
Cancel the command in unbuffered QueryAsync

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -4327,6 +4327,10 @@ Type type, IDataReader reader, int startBound = 0, int length = -1, bool returnN
             }
             private void NextResult()
             {
+                // this seems insane but its to allow cancelling out of deferred executions.
+                // if you try to read again you'll get the object disposed exception.
+                // however, it seems reasonable to want to dispose of the enumerator.
+                if (reader == null) return;
                 if (reader.NextResult())
                 {
                     readCount++;


### PR DESCRIPTION
This is an optimization for SQL Server and potentially other providers.
Currently, if you Dispose an IEnumerable produced from QueryAsync .NET
will still run the SqlCommand through to calculate statistics and assign
out params. 