### PR TITLE
SqlBuilder for .NET 3.5

### DIFF
--- a/Dapper.SqlBuilder NET35/Dapper.SqlBuilder NET35.csproj
+++ b/Dapper.SqlBuilder NET35/Dapper.SqlBuilder NET35.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{13A52642-B160-4050-A101-F64FABE7AF9D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Dapper.SqlBuilder</RootNamespace>
+    <AssemblyName>Dapper.SqlBuilder NET35</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;CSHARP30</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Dapper.SqlBuilder\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\Dapper.SqlBuilder\SqlBuilder.cs">
+      <Link>SqlBuilder.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dapper NET35\Dapper NET35.csproj">
+      <Project>{b26305d8-3a89-4d68-a981-9bbf378b81fa}</Project>
+      <Name>Dapper NET35</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -23,7 +23,11 @@ namespace Dapper
             string prefix;
             string postfix;
 
+#if CSHARP30
+            public Clauses(string joiner, string prefix, string postfix)
+#else
             public Clauses(string joiner, string prefix = "", string postfix = "")
+#endif
             {
                 this.joiner = joiner;
                 this.prefix = prefix;
@@ -46,8 +50,8 @@ namespace Dapper
                                   " ( " +
                                   string.Join(" OR ", this.Where(a => a.IsInclusive).Select(c => c.Sql).ToArray()) +
                                   " ) "
-                              })) + postfix
-                    : prefix + string.Join(joiner, this.Select(c => c.Sql)) + postfix;
+                              }).ToArray()) + postfix
+                    : prefix + string.Join(joiner, this.Select(c => c.Sql).ToArray()) + postfix;
             }
         }
 
@@ -58,7 +62,11 @@ namespace Dapper
             readonly object initParams;
             int dataSeq = -1; // Unresolved
 
+#if CSHARP30
+            public Template(SqlBuilder builder, string sql, object parameters)
+#else
             public Template(SqlBuilder builder, string sql, dynamic parameters)
+#endif
             {
                 this.initParams = parameters;
                 this.sql = sql;
@@ -101,12 +109,20 @@ namespace Dapper
         {
         }
 
+#if CSHARP30
+        public Template AddTemplate(string sql, object parameters)
+#else
         public Template AddTemplate(string sql, dynamic parameters = null)
+#endif
         {
             return new Template(this, sql, parameters);
         }
 
-        void AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool IsInclusive = false)
+#if CSHARP30
+        void AddClause(string name, string sql, object parameters, string joiner, string prefix, string postfix, bool isInclusive)
+#else
+        void AddClause(string name, string sql, object parameters, string joiner, string prefix = "", string postfix = "", bool isInclusive = false)
+#endif
         {
             Clauses clauses;
             if (!data.TryGetValue(name, out clauses))
@@ -114,79 +130,129 @@ namespace Dapper
                 clauses = new Clauses(joiner, prefix, postfix);
                 data[name] = clauses;
             }
-            clauses.Add(new Clause { Sql = sql, Parameters = parameters, IsInclusive = IsInclusive });
+            clauses.Add(new Clause { Sql = sql, Parameters = parameters, IsInclusive = isInclusive });
             seq++;
         }
-
+        
+#if CSHARP30
+        public SqlBuilder Intersect(string sql, object parameters)
+#else
         public SqlBuilder Intersect(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("intersect", sql, parameters, joiner: "\nINTERSECT\n ", prefix: "\n ", postfix: "\n");
+            AddClause("intersect", sql, parameters, "\nINTERSECT\n ", "\n ", "\n", false);
             return this;
         }
         
+#if CSHARP30
+        public SqlBuilder InnerJoin(string sql, object parameters)
+#else
         public SqlBuilder InnerJoin(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("innerjoin", sql, parameters, joiner: "\nINNER JOIN ", prefix: "\nINNER JOIN ", postfix: "\n");
-            return this;
-        }
-
-        public SqlBuilder LeftJoin(string sql, dynamic parameters = null)
-        {
-            AddClause("leftjoin", sql, parameters, joiner: "\nLEFT JOIN ", prefix: "\nLEFT JOIN ", postfix: "\n");
-            return this;
-        }
-
-        public SqlBuilder RightJoin(string sql, dynamic parameters = null)
-        {
-            AddClause("rightjoin", sql, parameters, joiner: "\nRIGHT JOIN ", prefix: "\nRIGHT JOIN ", postfix: "\n");
-            return this;
-        }
-
-        public SqlBuilder Where(string sql, dynamic parameters = null)
-        {
-            AddClause("where", sql, parameters, " AND ", prefix: "WHERE ", postfix: "\n");
-            return this;
-        }
-
-        public SqlBuilder OrWhere(string sql, dynamic parameters = null)
-        {
-            AddClause("where", sql, parameters, " AND ", prefix: "WHERE ", postfix: "\n", IsInclusive: true);
+            AddClause("innerjoin", sql, parameters, "\nINNER JOIN ", "\nINNER JOIN ", "\n", false);
             return this;
         }
         
+#if CSHARP30
+        public SqlBuilder LeftJoin(string sql, object parameters)
+#else
+        public SqlBuilder LeftJoin(string sql, dynamic parameters = null)
+#endif
+        {
+            AddClause("leftjoin", sql, parameters, "\nLEFT JOIN ", "\nLEFT JOIN ", "\n", false);
+            return this;
+        }
+
+        
+#if CSHARP30
+        public SqlBuilder RightJoin(string sql, object parameters)
+#else
+        public SqlBuilder RightJoin(string sql, dynamic parameters = null)
+#endif
+        {
+            AddClause("rightjoin", sql, parameters, "\nRIGHT JOIN ", "\nRIGHT JOIN ", "\n", false);
+            return this;
+        }
+
+        
+#if CSHARP30
+        public SqlBuilder Where(string sql, object parameters)
+#else
+        public SqlBuilder Where(string sql, dynamic parameters = null)
+#endif
+        {
+            AddClause("where", sql, parameters, " AND ", "WHERE ", "\n", false);
+            return this;
+        }
+        
+#if CSHARP30
+        public SqlBuilder OrWhere(string sql, object parameters)
+#else
+        public SqlBuilder OrWhere(string sql, dynamic parameters = null)
+#endif
+        {
+            AddClause("where", sql, parameters, " AND ", "WHERE ", "\n", true);
+            return this;
+        }
+        
+#if CSHARP30
+        public SqlBuilder OrderBy(string sql, object parameters)
+#else
         public SqlBuilder OrderBy(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("orderby", sql, parameters, " , ", prefix: "ORDER BY ", postfix: "\n");
+            AddClause("orderby", sql, parameters, " , ", "ORDER BY ", "\n", false);
             return this;
         }
-
+        
+#if CSHARP30
+        public SqlBuilder Select(string sql, object parameters)
+#else
         public SqlBuilder Select(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("select", sql, parameters, " , ", prefix: "", postfix: "\n");
+            AddClause("select", sql, parameters, " , ", "", "\n", false);
             return this;
         }
-
+        
+#if CSHARP30
+        public SqlBuilder AddParameters(object parameters)
+#else
         public SqlBuilder AddParameters(dynamic parameters)
+#endif
         {
-            AddClause("--parameters", "", parameters, "");
+            AddClause("--parameters", "", parameters, "", "", "", false);
             return this;
         }
-
+        
+#if CSHARP30
+        public SqlBuilder Join(string sql, object parameters)
+#else
         public SqlBuilder Join(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("join", sql, parameters, joiner: "\nJOIN ", prefix: "\nJOIN ", postfix: "\n");
+            AddClause("join", sql, parameters, "\nJOIN ", "\nJOIN ", "\n", false);
             return this;
         }
-
+        
+#if CSHARP30
+        public SqlBuilder GroupBy(string sql, object parameters)
+#else
         public SqlBuilder GroupBy(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("groupby", sql, parameters, joiner: " , ", prefix: "\nGROUP BY ", postfix: "\n");
+            AddClause("groupby", sql, parameters, " , ", "\nGROUP BY ", "\n", false);
             return this;
         }
-
+        
+#if CSHARP30
+        public SqlBuilder Having(string sql, object parameters)
+#else
         public SqlBuilder Having(string sql, dynamic parameters = null)
+#endif
         {
-            AddClause("having", sql, parameters, joiner: "\nAND ", prefix: "HAVING ", postfix: "\n");
+            AddClause("having", sql, parameters, "\nAND ", "HAVING ", "\n", false);
             return this;
         }
     }

--- a/Dapper.sln
+++ b/Dapper.sln
@@ -61,6 +61,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.EntityFramework NET45 SNK", "Dapper.EntityFramework NET45 SNK\Dapper.EntityFramework NET45 SNK.csproj", "{7169A2C1-F57E-4288-B22D-52394DD2EC06}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.SqlBuilder NET45", "Dapper.SqlBuilder NET45\Dapper.SqlBuilder NET45.csproj", "{B83D86B2-79C0-46AA-B51B-03730256FAAC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.SqlBuilder NET35", "Dapper.SqlBuilder NET35\Dapper.SqlBuilder NET35.csproj", "{13A52642-B160-4050-A101-F64FABE7AF9D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -282,6 +283,16 @@ Global
 		{B83D86B2-79C0-46AA-B51B-03730256FAAC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B83D86B2-79C0-46AA-B51B-03730256FAAC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B83D86B2-79C0-46AA-B51B-03730256FAAC}.Release|x86.ActiveCfg = Release|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{13A52642-B160-4050-A101-F64FABE7AF9D}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
According to: http://stackoverflow.com/questions/29151282/does-dapper-sqlbuilder-exist-for-net-3-5.

- New project which targets .NET 3.5.
- `CSHARP30` debug symbol.
- `#if` statements for dynamic parameters.
- Used `.ToArray()` with `string.Join()`.
- Removed named arguments.