### PR TITLE
fix  value type bug

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -3432,6 +3432,10 @@ this IDbConnection cnn, string sql, Func<TFirst, TSecond, TThird, TFourth, TRetu
             return r =>
             {
                 var val = r.GetValue(index);
+                if (type.IsValueType)
+                {
+                    return val is DBNull ? 0 : val;
+                }
                 return val is DBNull ? null : val;
             };
         }


### PR DESCRIPTION
during call the method “ QueryAsync<T>”，I found that if the T is value type ,it will cause the  System.NullReferenceException.I find out that the reason is that  the it add null to the List< value type >
                             buffer.Add((T)func(reader));
SqlMapperAsync--Line98
So I add a Condition to judge  the database return
   