### PR TITLE
Fix #253, use user defined TypeHandlers over internal implementations.

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -885,15 +885,16 @@ namespace Dapper
             {
                 return DbType.Binary;
             }
+            if (typeHandlers.TryGetValue(type, out handler))
+            {
+                return DbType.Object;
+            }
             if (typeof(IEnumerable).IsAssignableFrom(type))
             {
                 return DynamicParameters.EnumerableMultiParameter;
             }
 
-            if (typeHandlers.TryGetValue(type, out handler))
-            {
-                return DbType.Object;
-            }
+
             switch (type.FullName)
             {
                 case "Microsoft.SqlServer.Types.SqlGeography":


### PR DESCRIPTION
basically SqlMapper was using its own internal IEnumerable type handling even if the user has defined their own type handler for IEnumerable types (e.g. List<String>).

I've switched the order so it will check if the user has defined a type handler for this, and then use the IEnumerable implementation.
Also I added two tests, to DapperTests NET40 with a very simple List<String> TypeHandler implementation that will read Strings into a List<String> by splitting the string comma. And also will use join a list by comma and set a parameter from a List<String>.