### PR TITLE
Added extension method to simplify using SqlBuilder.Templates with Query method

### DIFF
--- a/Dapper.SqlBuilder NET45/Dapper.SqlBuilder NET45.csproj
+++ b/Dapper.SqlBuilder NET45/Dapper.SqlBuilder NET45.csproj
@@ -39,6 +39,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Dapper.SqlBuilder\DapperSqlBuilderMixin.cs">
+      <Link>DapperSqlBuilderMixin.cs</Link>
+    </Compile>
     <Compile Include="..\Dapper.SqlBuilder\SqlBuilder.cs">
       <Link>SqlBuilder.cs</Link>
     </Compile>

--- a/Dapper.SqlBuilder/Dapper.SqlBuilder.csproj
+++ b/Dapper.SqlBuilder/Dapper.SqlBuilder.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DapperSqlBuilderMixin.cs" />
     <Compile Include="SqlBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Dapper.SqlBuilder/DapperSqlBuilderMixin.cs
+++ b/Dapper.SqlBuilder/DapperSqlBuilderMixin.cs
@@ -21,5 +21,19 @@ namespace Dapper
 
 			return cnn.Query<TReturn>(query.RawSql, query.Parameters);
 		}
+
+		public static IEnumerable<dynamic> Query(
+			this IDbConnection cnn,
+			SqlBuilder.Template query,
+			IDbTransaction transaction = null,
+			bool buffered = true,
+			int? commandTimeout = null,
+			CommandType? commandType = null
+		)
+		{
+			if (query == null) throw new ArgumentNullException("query");
+
+			return cnn.Query(query.RawSql, query.Parameters);
+		}
 	}
 }

--- a/Dapper.SqlBuilder/DapperSqlBuilderMixin.cs
+++ b/Dapper.SqlBuilder/DapperSqlBuilderMixin.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+namespace Dapper
+{
+	public static class DapperSqlBuilderMixin
+	{
+		public static IEnumerable<TReturn> Query<TReturn>(
+			this IDbConnection cnn, 
+			SqlBuilder.Template query, 
+			IDbTransaction transaction = null, 
+			bool buffered = true, 
+			int? commandTimeout = null, 
+			CommandType? commandType = null
+		)
+		{
+			if (query == null) throw new ArgumentNullException("query");
+
+			return cnn.Query<TReturn>(query.RawSql, query.Parameters);
+		}
+	}
+}


### PR DESCRIPTION
Added the static DapperSqlBuilderMixin class inside the SqlBuilder project to provide SqlSpecific extensions to Dapper.

The first extension method implemented here is a method simplifying the use of SqlBuilder.Template with the Query method. So instead of writing

`cnn.Query(template.RawSql, template.Parameters, ...);`

the user can write

`cnn.Query(template, ...);`
