### PR TITLE
SqlMapper global/default CommandTimeout

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -253,6 +253,30 @@ namespace Dapper
     static partial class SqlMapper
     {
         /// <summary>
+        /// Permits specifying certain SqlMapper values globally.
+        /// </summary>
+        public static class Settings
+        {
+            static Settings()
+            {
+                SetDefaults();
+            }
+
+            /// <summary>
+            /// Resets all Settings to their default values
+            /// </summary>
+            public static void SetDefaults()
+            {
+                CommandTimeout = null;
+            }
+
+            /// <summary>
+            /// Specifies the default Command Timeout for all Queries
+            /// </summary>
+            public static int? CommandTimeout { get; set; }
+        }
+
+        /// <summary>
         /// Implement this interface to pass an arbitrary db specific set of parameters to Dapper
         /// </summary>
         public partial interface IDynamicParameters

--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -183,7 +183,13 @@ namespace Dapper
                 cmd.Transaction = transaction;
             cmd.CommandText = commandText;
             if (commandTimeout.HasValue)
+            {
                 cmd.CommandTimeout = commandTimeout.Value;
+            }
+            else if (SqlMapper.Settings.CommandTimeout.HasValue)
+            {
+                cmd.CommandTimeout = SqlMapper.Settings.CommandTimeout.Value;
+            }
             if (commandType.HasValue)
                 cmd.CommandType = commandType.Value;
             if (paramReader != null)


### PR DESCRIPTION
The way this new property works is by looking at the nullable `commandTimeout` parameter passed to the `CommandDefinition` class, and if null, use the new `CommandTimeout` Setting.

Dapper works via Extension Methods, which are static, therefore not allowing instantiated versions to hold different values. I find that this is OK, given that the option to specify the Command Timeout is provided on each call to `Execute`, `ExecuteReader`, `Query`, and `QueryMultiple`.

An alternative, which I currently use, but do not like the additional layer is as follows:
- Create a new class which inherits from `DbConnection`
- Act as pass-thru on all of the overridable methods, except `CreateDbCommand` (which is more involved)
- In `CreateDbCommand`, hold the return value in a variable, modify the `CommandTimeout` property as desired, and return it
- *See sample class here: [DB Connection Class with default CommandTimeout](https://gist.github.com/176f853a25e00e9abc37.git)*

Additional discussion on Issue #282.

I hope this initial design helps pave the way for additional settings and features.