### PR TITLE
TypeHandler should be supported for enum

### DIFF
--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -4573,5 +4573,34 @@ end");
             var value = dbParams.Get<int>("Field1");
             value.IsEqualTo(1);
         }
+
+        enum TestEnum2
+        {
+            Bla = 1
+        }
+        class TestEnumClassNoNull2
+        {
+            public TestEnum2 EnumEnum { get; set; }
+        }
+        class TestEnum2Handler : Dapper.SqlMapper.TypeHandler<TestEnum2>
+        {
+            public static readonly TestEnum2Handler Default = new TestEnum2Handler();
+
+            public override void SetValue(IDbDataParameter parameter, TestEnum2 value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override TestEnum2 Parse(object value)
+            {
+                // Simulate custom deserialize DB value to enum value
+                return TestEnum2.Bla;
+            }
+        }
+        public void TestCustomEnumTypeHandler()
+        {
+            Dapper.SqlMapper.AddTypeHandler(TestEnum2Handler.Default);
+            connection.Query<TestEnumClassNoNull2>("select 'RandomStuff' as [EnumEnum]").First().EnumEnum.IsEqualTo(TestEnum2.Bla);
+        }
     }
 }


### PR DESCRIPTION
In the database, I'm storing single character status codes, and an `enum` to match the status codes. However, since the status codes are not integer and not direct string match against the enum I created, I implemented a `TypeHandler` to do custom deserialization from the status code to the enum. Then I found out Dapper will not call the `TypeHandler` for enum types, so here's the fix.

Basically I moved the `TypeHandler` cache check to the beginning of the block even before enum value processing because I believe user-defined TypeHandlers should come first before anything else, no?