### PR TITLE
Added support to automatically expand IEnumerables of >2100 parameters into a TVP when configured. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ NuGet.exe
 *.nupkg
 .docstats
 *.ide/
+
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/packages/repositories.config


### PR DESCRIPTION
**Edit:** Not sure what I did to close #285.  This is the new commit to reopen.  I'll copy the comments from the original request.

**Original Request:** 
In our usage of Dapper, we occasionally run into lists with many parameters.  While it is rare that the count exceeds 2100, it's not unheard of.  

This patch allows me to register a UDT on a per-type basis, and will automatically switch to a TVP if the max is exceeded.

```C#
Dapper.SqlMapper.Expander.Add(typeof(int), new Dapper.SqlMapper.ExpanderRegistration() { UdtTypeName = "IntList", UdtFieldName = "Id", Type = typeof(int), Count = 2000 });
```

Then, code like this will use multiple parameters
```C#
var ids = Enumerable.Range(20, 200);
var sql = "SELECT COUNT(*) FROM dbo.AutoExpand WHERE Id IN @ids";
var results connection.Query(sql, new { ids })
```

e.g.
```SQL
SELECT COUNT(*) FROM dbo.AutoExpand WHERE Id IN (@ids1, @ids2, @ids3 ... )
```

And when the enumerable exceeds a configured count, Dapper automaticaly switches to a strongly typed TVP:
e.g. 
```SQL
DECLARE @ids IntList
INSERT INTO @ids (Id) VALUES (1)
... 
INSERT INTO @ids (Id) VALUES (2000)

SELECT COUNT(*) FROM dbo.AutoExpand WHERE Id IN (SELECT Id from @ids)
```

It's still a little rough around the edges, but if there's any interest in merging this in, I'll clean it up.  Let me know. 

Thanks