### PR TITLE
Brackets around property names in Update & Delete

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -345,7 +345,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < nonIdProps.Count(); i++)
             {
                 var property = nonIdProps.ElementAt(i);
-                sb.AppendFormat("{0} = @{1}", property.Name, property.Name);
+                sb.AppendFormat("[{0}] = @{1}", property.Name, property.Name);
                 if (i < nonIdProps.Count() - 1)
                     sb.AppendFormat(", ");
             }
@@ -353,7 +353,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < keyProperties.Count(); i++)
             {
                 var property = keyProperties.ElementAt(i);
-                sb.AppendFormat("{0} = @{1}", property.Name, property.Name);
+                sb.AppendFormat("[{0}] = @{1}", property.Name, property.Name);
                 if (i < keyProperties.Count() - 1)
                     sb.AppendFormat(" and ");
             }
@@ -390,7 +390,7 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < keyProperties.Count(); i++)
             {
                 var property = keyProperties.ElementAt(i);
-                sb.AppendFormat("{0} = @{1}", property.Name, property.Name);
+                sb.AppendFormat("[{0}] = @{1}", property.Name, property.Name);
                 if (i < keyProperties.Count() - 1)
                     sb.AppendFormat(" and ");
             }


### PR DESCRIPTION
Modified Update & Delete method to be consistent with Insert by adding brackets around property names.I did this cause I thought it was annoying that I could do an insert without problems but had to resort to a type mapping when doing an update, all because of a property name which was a keyword in sql