### PR TITLE
Update Contrib README with small nuance about Delete

### DIFF
--- a/Dapper.Contrib/Readme.md
+++ b/Dapper.Contrib/Readme.md
@@ -87,7 +87,7 @@ connection.Update(cars);
 
 `Delete` methods
 -------
-Delete one specific entity
+Delete an entity by the specified `[Key]` property
 
 ```csharp
 connection.Delete(new Car() { Id = 1 });


### PR DESCRIPTION
Deleting an entity will delete only by a specified key property and not by any specified parameter

Illustrated by the following case: 

```csharp
[Table ("employee")]
public class Employee
{
    public int Id { get; set; }
    public string Name { get; set; }
}

// Doesn't work since "Name" isn't a key
_conn.Delete(new Employee { Name = "foo" });

// Works since "Id" is a key
_conn.Delete(new Employee { Id = 14 });
```