### PR TITLE
remove commented json so dnx tooling doesn't break

### DIFF
--- a/Dapper.DNX.Tests/project.json
+++ b/Dapper.DNX.Tests/project.json
@@ -46,7 +46,6 @@
         "System.Threading": "4.0.10-beta-*",
         "System.Threading.Thread": "4.0.0-beta-*",
         "System.Reflection.TypeExtensions": "4.0.0-beta-*"
-        //"System.Xml": "4.0.10-beta-*"
       }
     }
   }

--- a/Dapper/project.json
+++ b/Dapper/project.json
@@ -27,14 +27,6 @@
                 "System.Data": "4.0.0.0"
             }
         },
-        //"net35": {
-        //    "compilationOptions": { "warningsAsErrors": true, "languageVersion": "csharp3", "define": ["CSHARP30"] },
-        //    "dependencies": {
-        //    },
-        //    "frameworkAssemblies": {
-        //        "System.Data":  "4.0.0.0"
-        //    }
-        //},
         "dnx451": {
             "compilationOptions": { "define": [ "ASYNC" ], "warningsAsErrors": true },
             "dependencies": {


### PR DESCRIPTION
These comments break dnu out of the box, and there isn't any .net 3.5 support planned for dnx, so I recommend just removing these.