### PR TITLE
DBMS selection for extra features overidable in one place

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -5224,7 +5224,7 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
         /// </summary>
         public static Func<IDbConnection, DbmsType> GetDbmsTypeFromConnection = (connection) =>
         {
-            string name = connection == null ? null : connection.GetType().Name;
+            string name = connection == null ? null : connection.GetType().Name.ToLowerInvariant();
             switch (name)
             {
                 case "npgsqlconnection":

--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -5195,14 +5195,17 @@ string name, object value = null, DbType? dbType = null, ParameterDirection? dir
     /// </summary>
     partial class FeatureSupport
     {
+        private static readonly FeatureSupport 
+           @default = new FeatureSupport(false),		
+           postgres = new FeatureSupport(true);
         /// <summary>
         /// Gets the featureset based on the passed connection
         /// </summary>
         public static FeatureSupport Get(IDbConnection connection)
         {
             string name = connection == null ? null : connection.GetType().Name;
-            if (Config.GetDbmsType(connection) == DbmsType.Postgres) return new FeatureSupport(true); //Postgresql supports arrays
-            return new FeatureSupport(false);
+            if (Config.GetDbmsType(connection) == DbmsType.Postgres) return postgres; //Postgresql supports arrays
+            return @default;
         }
         private FeatureSupport(bool arrays)
         {

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -414,6 +414,8 @@ namespace Dapper.Contrib.Extensions
             return deleted > 0;
         }
 
+        //State to suoport getter on GetDatabaseType, to be removed when GetDatabaseType is permanantly obsoleted.
+        private static GetDatabaseTypeDelegate DatabaseTypeDelegate;
         /// <summary>
         /// Specifies a custom callback that detects the database type instead of relying on the default strategy (the name of the connection type object).
         /// Please note that this callback is global and will be used by all the calls that require a database specific adapter.
@@ -421,11 +423,16 @@ namespace Dapper.Contrib.Extensions
         [Obsolete("Set Dapper.Config.GetDbmsTypeFromConnection instead, this gets used for more than just extensions")]
         public static GetDatabaseTypeDelegate GetDatabaseType
         {
+            get
+            {
+                return DatabaseTypeDelegate;
+            }
             set
             {
                 //This is only here so that people using the delegate wont break
                 Dapper.Config.GetDbmsTypeFromConnection = (connection) =>
                 {
+                    DatabaseTypeDelegate = value;
                     var name = value(connection).ToLowerInvariant();
                     switch (name)
                     {

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -37,12 +37,12 @@ namespace Dapper.Contrib.Extensions
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> GetQueries = new ConcurrentDictionary<RuntimeTypeHandle, string>();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> TypeTableName = new ConcurrentDictionary<RuntimeTypeHandle, string>();
 
-        private static readonly Dictionary<string, ISqlAdapter> AdapterDictionary = new Dictionary<string, ISqlAdapter> {
-																							{"sqlconnection", new SqlServerAdapter()},
-																							{"sqlceconnection", new SqlCeServerAdapter()},
-																							{"npgsqlconnection", new PostgresAdapter()},
-																							{"sqliteconnection", new SQLiteAdapter()}
-																						};
+        private static readonly Dictionary<DbmsType, ISqlAdapter> AdapterDictionary = new Dictionary<DbmsType, ISqlAdapter>() {
+                                                                                            {DbmsType.TSql, new SqlServerAdapter()},
+                                                                                            {DbmsType.SqlCe, new SqlCeServerAdapter()},
+                                                                                            {DbmsType.Postgres, new PostgresAdapter()},
+                                                                                            {DbmsType.SqlLite, new SQLiteAdapter()}
+                                                                                        };
 
         private static IEnumerable<PropertyInfo> ComputedPropertiesCache(Type type)
         {
@@ -418,26 +418,35 @@ namespace Dapper.Contrib.Extensions
         /// Specifies a custom callback that detects the database type instead of relying on the default strategy (the name of the connection type object).
         /// Please note that this callback is global and will be used by all the calls that require a database specific adapter.
         /// </summary>
-        public static GetDatabaseTypeDelegate GetDatabaseType;
+        [Obsolete("Set Dapper.Config.GetDbmsTypeFromConnection instead, this gets used for more than just extensions")]
+        public static GetDatabaseTypeDelegate GetDatabaseType
+        {
+            set
+            {
+                //This is only here so that people using the delegate wont break
+                Dapper.Config.GetDbmsTypeFromConnection = (connection) =>
+                {
+                    var name = value(connection).ToLowerInvariant();
+                    switch (name)
+                    {
+                        case "npgsqlconnection":
+                            return DbmsType.Postgres;
+                        case "sqliteconnection":
+                            return DbmsType.SqlLite;
+                        case "sqlceconnection":
+                            return DbmsType.SqlCe;
+                        default:
+                            return DbmsType.TSql;
+                    }
+                };
+            }
+        }
 
 
         private static ISqlAdapter GetFormatter(IDbConnection connection)
         {
-            string name;
-            if (GetDatabaseType != null)
-            {
-                name = GetDatabaseType(connection);
-                if (name != null)
-                    name = name.ToLower();
-            }
-            else
-            {
-                name = connection.GetType().Name.ToLower();
-            }
-
-            return !AdapterDictionary.ContainsKey(name) ?
-                new SqlServerAdapter() :
-                AdapterDictionary[name];
+            return AdapterDictionary.ContainsKey(Dapper.Config.GetDbmsType(connection)) ?
+                AdapterDictionary[Dapper.Config.GetDbmsType(connection)] : new SqlServerAdapter();
         }
 
         static class ProxyGenerator


### PR DESCRIPTION
Previously only overridable inside the Contrib extensions now overridable for
both core and extensions. Means that if you are using a wrapped
connection you can change the detection method to suit.