### PR TITLE
Update SqlMapper.cs

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -378,6 +378,7 @@ namespace Dapper
                 parameter.Value = SanitizeParameterValue(value);
                 if (parameter is System.Data.SqlClient.SqlParameter)
                 {
+                    ((System.Data.SqlClient.SqlParameter)parameter).SqlDbType = SqlDbType.Udt;
                     ((System.Data.SqlClient.SqlParameter)parameter).UdtTypeName = udtTypeName;
                 }
             }


### PR DESCRIPTION
fixed the "UdtTypeName property must be set for UDT parameters" error.
C#  :  .net Framework 4.5.1
Sql server 2012