### PR TITLE
Always use TypeHandler for parameters if available

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -925,7 +925,7 @@ namespace Dapper
         internal static DbType LookupDbType(Type type, string name, bool demand, out ITypeHandler handler)
         {
             DbType dbType;
-            handler = null;
+            typeHandlers.TryGetValue(type, out handler);
             var nullUnderlyingType = Nullable.GetUnderlyingType(type);
             if (nullUnderlyingType != null) type = nullUnderlyingType;
             if (type.IsEnum() && !typeMap.ContainsKey(type))
@@ -940,7 +940,7 @@ namespace Dapper
             {
                 return DbType.Binary;
             }
-            if (typeHandlers.TryGetValue(type, out handler))
+            if (handler == null)
             {
                 return DbType.Object;
             }


### PR DESCRIPTION
TypeHandlers can override the logic for built-in SQL data types (int,
byte, DateTime etc.) when these are return values via
ITypeHandler.Parse, but ITypeHandler.SetValue was never being used for
parameters. Moved the typeHandlers.TryGetValue() call up to make sure a
type handler is always used if available.