### PR TITLE
Only set UdtTypeName when value isn't DBNull

### DIFF
--- a/Dapper NET40/SqlMapper.cs
+++ b/Dapper NET40/SqlMapper.cs
@@ -376,7 +376,7 @@ namespace Dapper
             void ITypeHandler.SetValue(IDbDataParameter parameter, object value)
             {
                 parameter.Value = SanitizeParameterValue(value);
-                if (parameter is System.Data.SqlClient.SqlParameter)
+                if (parameter is System.Data.SqlClient.SqlParameter && !(value is DBNull))
                 {
                     ((System.Data.SqlClient.SqlParameter)parameter).UdtTypeName = udtTypeName;
                 }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -3508,6 +3508,23 @@ option (optimize for (@vals unKnoWn))";
             row.Geometry.IsNotNull();
         }
 
+        public void NullableSqlGeometry()
+        {
+            Dapper.SqlMapper.ResetTypeHandlers();
+            connection.Execute("create table #SqlNullableGeo (id int, geometry geometry null)");
+
+            var obj = new HazSqlGeo
+            {
+                Id = 1,
+                Geometry = null
+            };
+            connection.Execute("insert #SqlNullableGeo(id, geometry) values (@Id, @Geometry)", obj);
+            var row = connection.Query<HazSqlGeo>("select * from #SqlNullableGeo where id=1").SingleOrDefault();
+            row.IsNotNull();
+            row.Id.IsEqualTo(1);
+            row.Geometry.IsNull();
+        }
+
         public void SqlHierarchyId_SO18888911()
         {
             Dapper.SqlMapper.ResetTypeHandlers();


### PR DESCRIPTION
Without this fix, trying to set a column of type `geometry` (and presumably other UDT types) causes an `ArgumentException` with the message: "UdtTypeName property must be set only for UDT parameters."

Only setting the `UdtTypeName` when the value is not `DBNull` resolves the problem.