### PR TITLE
Code improvements to utilize C# 6 features

### DIFF
--- a/Dapper/CommandFlags.cs
+++ b/Dapper/CommandFlags.cs
@@ -2,7 +2,6 @@
 
 namespace Dapper
 {
-
     /// <summary>
     /// Additional state flags that control command behaviour
     /// </summary>
@@ -13,18 +12,20 @@ namespace Dapper
         /// No additional flags
         /// </summary>
         None = 0,
+
         /// <summary>
         /// Should data be buffered before returning?
         /// </summary>
         Buffered = 1,
+
         /// <summary>
         /// Can async queries be pipelined?
         /// </summary>
         Pipelined = 2,
+
         /// <summary>
         /// Should the plan cache be bypassed?
         /// </summary>
         NoCache = 4,
     }
-
 }

--- a/Dapper/CustomPropertyTypeMap.cs
+++ b/Dapper/CustomPropertyTypeMap.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 
 namespace Dapper
 {
-
     /// <summary>
     /// Implements custom property mapping by user provided criteria (usually presence of some custom attribute with column to member mapping)
     /// </summary>
@@ -20,10 +19,14 @@ namespace Dapper
         public CustomPropertyTypeMap(Type type, Func<Type, string, PropertyInfo> propertySelector)
         {
             if (type == null)
-                throw new ArgumentNullException("type");
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
 
             if (propertySelector == null)
-                throw new ArgumentNullException("propertySelector");
+            {
+                throw new ArgumentNullException(nameof(propertySelector));
+            }
 
             _type = type;
             _propertySelector = propertySelector;
@@ -71,6 +74,4 @@ namespace Dapper
             return prop != null ? new SimpleMemberMap(columnName, prop) : null;
         }
     }
-
-
 }

--- a/Dapper/DataTableHandler.cs
+++ b/Dapper/DataTableHandler.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Data;
+
 #if !DNXCORE50
 namespace Dapper
 {
-    sealed class DataTableHandler : Dapper.SqlMapper.ITypeHandler
+    internal sealed class DataTableHandler : SqlMapper.ITypeHandler
     {
         public object Parse(Type destinationType, object value)
         {

--- a/Dapper/DbString.cs
+++ b/Dapper/DbString.cs
@@ -19,7 +19,7 @@ namespace Dapper
     /// <summary>
     /// This class represents a SQL string, it can be used if you need to denote your parameter is a Char vs VarChar vs nVarChar vs nChar
     /// </summary>
-    public sealed class DbString : Dapper.SqlMapper.ICustomQueryParameter
+    public sealed class DbString : SqlMapper.ICustomQueryParameter
     {
         /// <summary>
         /// Default value for IsAnsi.
@@ -41,22 +41,27 @@ namespace Dapper
             Length = -1;
             IsAnsi = IsAnsiDefault;
         }
+
         /// <summary>
-        /// Ansi vs Unicode 
+        /// Ansi vs Unicode
         /// </summary>
         public bool IsAnsi { get; set; }
+
         /// <summary>
-        /// Fixed length 
+        /// Fixed length
         /// </summary>
         public bool IsFixedLength { get; set; }
+
         /// <summary>
         /// Length of the string -1 for max
         /// </summary>
         public int Length { get; set; }
+
         /// <summary>
         /// The value of the string
         /// </summary>
         public string Value { get; set; }
+
         /// <summary>
         /// Add the parameter to the command... internal use only
         /// </summary>
@@ -83,5 +88,4 @@ namespace Dapper
             command.Parameters.Add(param);
         }
     }
-
 }

--- a/Dapper/DynamicParameters.CachedOutputSetters.cs
+++ b/Dapper/DynamicParameters.CachedOutputSetters.cs
@@ -1,18 +1,20 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+
 #if DNXCORE50
-using IDbDataParameter = global::System.Data.Common.DbParameter;
-using IDataParameter = global::System.Data.Common.DbParameter;
-using IDbTransaction = global::System.Data.Common.DbTransaction;
-using IDbConnection = global::System.Data.Common.DbConnection;
-using IDbCommand = global::System.Data.Common.DbCommand;
-using IDataReader = global::System.Data.Common.DbDataReader;
-using IDataRecord = global::System.Data.Common.DbDataReader;
-using IDataParameterCollection = global::System.Data.Common.DbParameterCollection;
-using DataException = global::System.InvalidOperationException;
-using ApplicationException = global::System.InvalidOperationException;
+using IDbDataParameter = System.Data.Common.DbParameter;
+using IDataParameter = System.Data.Common.DbParameter;
+using IDbTransaction = System.Data.Common.DbTransaction;
+using IDbConnection = System.Data.Common.DbConnection;
+using IDbCommand = System.Data.Common.DbCommand;
+using IDataReader = System.Data.Common.DbDataReader;
+using IDataRecord = System.Data.Common.DbDataReader;
+using IDataParameterCollection = System.Data.Common.DbParameterCollection;
+using DataException = System.InvalidOperationException;
+using ApplicationException = System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     partial class DynamicParameters

--- a/Dapper/DynamicParameters.ParamInfo.cs
+++ b/Dapper/DynamicParameters.ParamInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -12,25 +13,34 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     partial class DynamicParameters
     {
-        sealed class ParamInfo
+        private sealed class ParamInfo
         {
             public string Name { get; set; }
+
             public object Value { get; set; }
+
             public ParameterDirection ParameterDirection { get; set; }
+
             public DbType? DbType { get; set; }
+
             public int? Size { get; set; }
+
             public IDbDataParameter AttachedParam { get; set; }
+
             internal Action<object, DynamicParameters> OutputCallback { get; set; }
+
             internal object OutputTarget { get; set; }
+
             internal bool CameFromTemplate { get; set; }
 
             public byte? Precision { get; set; }
+
             public byte? Scale { get; set; }
         }
-
     }
 }

--- a/Dapper/FeatureSupport.cs
+++ b/Dapper/FeatureSupport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -12,12 +13,13 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     /// <summary>
     /// Handles variances in features per DBMS
     /// </summary>
-    class FeatureSupport
+    internal class FeatureSupport
     {
         private static readonly FeatureSupport
             @default = new FeatureSupport(false),
@@ -28,18 +30,22 @@ namespace Dapper
         /// </summary>
         public static FeatureSupport Get(IDbConnection connection)
         {
-            string name = connection == null ? null : connection.GetType().Name;
-            if (string.Equals(name, "npgsqlconnection", StringComparison.OrdinalIgnoreCase)) return postgres;
+            var name = connection?.GetType().Name;
+            if (string.Equals(name, "npgsqlconnection", StringComparison.OrdinalIgnoreCase))
+            {
+                return postgres;
+            }
             return @default;
         }
+
         private FeatureSupport(bool arrays)
         {
             Arrays = arrays;
         }
+
         /// <summary>
         /// True if the db supports array columns e.g. Postgresql
         /// </summary>
         public bool Arrays { get; private set; }
     }
-
 }

--- a/Dapper/SimpleMemberMap.cs
+++ b/Dapper/SimpleMemberMap.cs
@@ -6,13 +6,8 @@ namespace Dapper
     /// <summary>
     /// Represents simple member map for one of target parameter or property or field to source DataReader column
     /// </summary>
-    sealed class SimpleMemberMap : SqlMapper.IMemberMap
+    internal sealed class SimpleMemberMap : SqlMapper.IMemberMap
     {
-        private readonly string _columnName;
-        private readonly PropertyInfo _property;
-        private readonly FieldInfo _field;
-        private readonly ParameterInfo _parameter;
-
         /// <summary>
         /// Creates instance for simple property mapping
         /// </summary>
@@ -21,13 +16,17 @@ namespace Dapper
         public SimpleMemberMap(string columnName, PropertyInfo property)
         {
             if (columnName == null)
-                throw new ArgumentNullException("columnName");
+            {
+                throw new ArgumentNullException(nameof(columnName));
+            }
 
             if (property == null)
-                throw new ArgumentNullException("property");
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
-            _columnName = columnName;
-            _property = property;
+            ColumnName = columnName;
+            Property = property;
         }
 
         /// <summary>
@@ -38,13 +37,17 @@ namespace Dapper
         public SimpleMemberMap(string columnName, FieldInfo field)
         {
             if (columnName == null)
-                throw new ArgumentNullException("columnName");
+            {
+                throw new ArgumentNullException(nameof(columnName));
+            }
 
             if (field == null)
-                throw new ArgumentNullException("field");
+            {
+                throw new ArgumentNullException(nameof(field));
+            }
 
-            _columnName = columnName;
-            _field = field;
+            ColumnName = columnName;
+            Field = field;
         }
 
         /// <summary>
@@ -55,22 +58,23 @@ namespace Dapper
         public SimpleMemberMap(string columnName, ParameterInfo parameter)
         {
             if (columnName == null)
-                throw new ArgumentNullException("columnName");
+            {
+                throw new ArgumentNullException(nameof(columnName));
+            }
 
             if (parameter == null)
-                throw new ArgumentNullException("parameter");
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
 
-            _columnName = columnName;
-            _parameter = parameter;
+            ColumnName = columnName;
+            Parameter = parameter;
         }
 
         /// <summary>
         /// DataReader column name
         /// </summary>
-        public string ColumnName
-        {
-            get { return _columnName; }
-        }
+        public string ColumnName { get; }
 
         /// <summary>
         /// Target member type
@@ -79,42 +83,28 @@ namespace Dapper
         {
             get
             {
-                if (_field != null)
-                    return _field.FieldType;
+                if (Field != null)
+                {
+                    return Field.FieldType;
+                }
 
-                if (_property != null)
-                    return _property.PropertyType;
-
-                if (_parameter != null)
-                    return _parameter.ParameterType;
-
-                return null;
+                return Property?.PropertyType ?? Parameter?.ParameterType;
             }
         }
 
         /// <summary>
         /// Target property
         /// </summary>
-        public PropertyInfo Property
-        {
-            get { return _property; }
-        }
+        public PropertyInfo Property { get; }
 
         /// <summary>
         /// Target field
         /// </summary>
-        public FieldInfo Field
-        {
-            get { return _field; }
-        }
+        public FieldInfo Field { get; }
 
         /// <summary>
         /// Target constructor parameter
         /// </summary>
-        public ParameterInfo Parameter
-        {
-            get { return _parameter; }
-        }
+        public ParameterInfo Parameter { get; }
     }
-
 }

--- a/Dapper/SqlDataRecordHandler.cs
+++ b/Dapper/SqlDataRecordHandler.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using Microsoft.SqlServer.Server;
 
 #if !DNXCORE50
 namespace Dapper
 {
-    sealed class SqlDataRecordHandler : Dapper.SqlMapper.ITypeHandler
+    internal sealed class SqlDataRecordHandler : SqlMapper.ITypeHandler
     {
         public object Parse(Type destinationType, object value)
         {
@@ -14,7 +15,7 @@ namespace Dapper
 
         public void SetValue(IDbDataParameter parameter, object value)
         {
-            SqlDataRecordListTVPParameter.Set(parameter, value as IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord>, null);
+            SqlDataRecordListTVPParameter.Set(parameter, value as IEnumerable<SqlDataRecord>, null);
         }
     }
 }

--- a/Dapper/SqlDataRecordListTVPParameter.cs
+++ b/Dapper/SqlDataRecordListTVPParameter.cs
@@ -1,36 +1,42 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.SqlClient;
 using System.Reflection;
+using Microsoft.SqlServer.Server;
+
 #if !DNXCORE50
 namespace Dapper
 {
-
     /// <summary>
     /// Used to pass a IEnumerable&lt;SqlDataRecord&gt; as a SqlDataRecordListTVPParameter
     /// </summary>
-    sealed class SqlDataRecordListTVPParameter : Dapper.SqlMapper.ICustomQueryParameter
+    internal sealed class SqlDataRecordListTVPParameter : SqlMapper.ICustomQueryParameter
     {
-        private readonly IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord> data;
+        private readonly IEnumerable<SqlDataRecord> data;
         private readonly string typeName;
+
         /// <summary>
         /// Create a new instance of SqlDataRecordListTVPParameter
         /// </summary>
-        public SqlDataRecordListTVPParameter(IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord> data, string typeName)
+        public SqlDataRecordListTVPParameter(IEnumerable<SqlDataRecord> data, string typeName)
         {
             this.data = data;
             this.typeName = typeName;
         }
-        static readonly Action<System.Data.SqlClient.SqlParameter, string> setTypeName;
+
+        private static readonly Action<SqlParameter, string> setTypeName;
+
         static SqlDataRecordListTVPParameter()
         {
-            var prop = typeof(System.Data.SqlClient.SqlParameter).GetProperty("TypeName", BindingFlags.Instance | BindingFlags.Public);
+            var prop = typeof(SqlParameter).GetProperty("TypeName", BindingFlags.Instance | BindingFlags.Public);
             if (prop != null && prop.PropertyType == typeof(string) && prop.CanWrite)
             {
-                setTypeName = (Action<System.Data.SqlClient.SqlParameter, string>)
-                    Delegate.CreateDelegate(typeof(Action<System.Data.SqlClient.SqlParameter, string>), prop.GetSetMethod());
+                setTypeName = (Action<SqlParameter, string>)
+                              Delegate.CreateDelegate(typeof(Action<SqlParameter, string>), prop.GetSetMethod());
             }
         }
+
         void SqlMapper.ICustomQueryParameter.AddParameter(IDbCommand command, string name)
         {
             var param = command.CreateParameter();
@@ -38,10 +44,11 @@ namespace Dapper
             Set(param, data, typeName);
             command.Parameters.Add(param);
         }
-        internal static void Set(IDbDataParameter parameter, IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord> data, string typeName)
+
+        internal static void Set(IDbDataParameter parameter, IEnumerable<SqlDataRecord> data, string typeName)
         {
             parameter.Value = (object)data ?? DBNull.Value;
-            var sqlParam = parameter as System.Data.SqlClient.SqlParameter;
+            var sqlParam = parameter as SqlParameter;
             if (sqlParam != null)
             {
                 sqlParam.SqlDbType = SqlDbType.Structured;
@@ -49,6 +56,5 @@ namespace Dapper
             }
         }
     }
-
 }
 #endif

--- a/Dapper/SqlMapper.CacheInfo.cs
+++ b/Dapper/SqlMapper.CacheInfo.cs
@@ -19,14 +19,25 @@ namespace Dapper
 {
     partial class SqlMapper
     {
-        class CacheInfo
+        private class CacheInfo
         {
             public DeserializerState Deserializer { get; set; }
+
             public Func<IDataReader, object>[] OtherDeserializers { get; set; }
+
             public Action<IDbCommand, object> ParamReader { get; set; }
+
             private int hitCount;
-            public int GetHitCount() { return Interlocked.CompareExchange(ref hitCount, 0, 0); }
-            public void RecordHit() { Interlocked.Increment(ref hitCount); }
+
+            public int GetHitCount()
+            {
+                return Interlocked.CompareExchange(ref hitCount, 0, 0);
+            }
+
+            public void RecordHit()
+            {
+                Interlocked.Increment(ref hitCount);
+            }
         }
     }
 }

--- a/Dapper/SqlMapper.DapperRow.cs
+++ b/Dapper/SqlMapper.DapperRow.cs
@@ -1,40 +1,55 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Dapper
 {
     partial class SqlMapper
     {
-
         private sealed class DapperRow
-            : System.Dynamic.IDynamicMetaObjectProvider
-            , IDictionary<string, object>
+            : IDynamicMetaObjectProvider
+              , IDictionary<string, object>
         {
-            readonly DapperTable table;
-            object[] values;
+            private readonly DapperTable table;
+            private object[] values;
 
             public DapperRow(DapperTable table, object[] values)
             {
-                if (table == null) throw new ArgumentNullException("table");
-                if (values == null) throw new ArgumentNullException("values");
+                if (table == null)
+                {
+                    throw new ArgumentNullException(nameof(table));
+                }
+                if (values == null)
+                {
+                    throw new ArgumentNullException(nameof(values));
+                }
                 this.table = table;
                 this.values = values;
             }
+
             private sealed class DeadValue
             {
                 public static readonly DeadValue Default = new DeadValue();
-                private DeadValue() { }
+
+                private DeadValue()
+                {
+                }
             }
+
             int ICollection<KeyValuePair<string, object>>.Count
             {
                 get
                 {
-                    int count = 0;
-                    for (int i = 0; i < values.Length; i++)
+                    var count = 0;
+                    for (var i = 0; i < values.Length; i++)
                     {
-                        if (!(values[i] is DeadValue)) count++;
+                        if (!(values[i] is DeadValue))
+                        {
+                            count++;
+                        }
                     }
                     return count;
                 }
@@ -44,14 +59,16 @@ namespace Dapper
             {
                 var index = table.IndexOfName(name);
                 if (index < 0)
-                { // doesn't exist
+                {
+                    // doesn't exist
                     value = null;
                     return false;
                 }
                 // exists, **even if** we don't have a value; consider table rows heterogeneous
                 value = index < values.Length ? values[index] : null;
                 if (value is DeadValue)
-                { // pretend it isn't here
+                {
+                    // pretend it isn't here
                     value = null;
                     return false;
                 }
@@ -78,10 +95,10 @@ namespace Dapper
                 return sb.Append('}').__ToStringRecycle();
             }
 
-            System.Dynamic.DynamicMetaObject System.Dynamic.IDynamicMetaObjectProvider.GetMetaObject(
-                System.Linq.Expressions.Expression parameter)
+            DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(
+                Expression parameter)
             {
-                return new DapperRowMetaObject(parameter, System.Dynamic.BindingRestrictions.Empty, this);
+                return new DapperRowMetaObject(parameter, BindingRestrictions.Empty, this);
             }
 
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
@@ -89,7 +106,7 @@ namespace Dapper
                 var names = table.FieldNames;
                 for (var i = 0; i < names.Length; i++)
                 {
-                    object value = i < values.Length ? values[i] : null;
+                    var value = i < values.Length ? values[i] : null;
                     if (!(value is DeadValue))
                     {
                         yield return new KeyValuePair<string, object>(names[i], value);
@@ -103,7 +120,6 @@ namespace Dapper
             }
 
             #region Implementation of ICollection<KeyValuePair<string,object>>
-
             void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
             {
                 IDictionary<string, object> dic = this;
@@ -111,9 +127,12 @@ namespace Dapper
             }
 
             void ICollection<KeyValuePair<string, object>>.Clear()
-            { // removes values for **this row**, but doesn't change the fundamental table
-                for (int i = 0; i < values.Length; i++)
+            {
+                // removes values for **this row**, but doesn't change the fundamental table
+                for (var i = 0; i < values.Length; i++)
+                {
                     values[i] = DeadValue.Default;
+                }
             }
 
             bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
@@ -136,19 +155,17 @@ namespace Dapper
                 return dic.Remove(item.Key);
             }
 
-            bool ICollection<KeyValuePair<string, object>>.IsReadOnly
-            {
-                get { return false; }
-            }
-
+            bool ICollection<KeyValuePair<string, object>>.IsReadOnly => false;
             #endregion
 
             #region Implementation of IDictionary<string,object>
-
             bool IDictionary<string, object>.ContainsKey(string key)
             {
-                int index = table.IndexOfName(key);
-                if (index < 0 || index >= values.Length || values[index] is DeadValue) return false;
+                var index = table.IndexOfName(key);
+                if (index < 0 || index >= values.Length || values[index] is DeadValue)
+                {
+                    return false;
+                }
                 return true;
             }
 
@@ -159,26 +176,41 @@ namespace Dapper
 
             bool IDictionary<string, object>.Remove(string key)
             {
-                int index = table.IndexOfName(key);
-                if (index < 0 || index >= values.Length || values[index] is DeadValue) return false;
+                var index = table.IndexOfName(key);
+                if (index < 0 || index >= values.Length || values[index] is DeadValue)
+                {
+                    return false;
+                }
                 values[index] = DeadValue.Default;
                 return true;
             }
 
             object IDictionary<string, object>.this[string key]
             {
-                get { object val; TryGetValue(key, out val); return val; }
-                set { SetValue(key, value, false); }
+                get
+                {
+                    object val;
+                    TryGetValue(key, out val);
+                    return val;
+                }
+                set
+                {
+                    SetValue(key, value, false);
+                }
             }
 
             public object SetValue(string key, object value)
             {
                 return SetValue(key, value, false);
             }
+
             private object SetValue(string key, object value, bool isAdd)
             {
-                if (key == null) throw new ArgumentNullException("key");
-                int index = table.IndexOfName(key);
+                if (key == null)
+                {
+                    throw new ArgumentNullException(nameof(key));
+                }
+                var index = table.IndexOfName(key);
                 if (index < 0)
                 {
                     index = table.AddField(key);
@@ -186,15 +218,15 @@ namespace Dapper
                 else if (isAdd && index < values.Length && !(values[index] is DeadValue))
                 {
                     // then semantically, this value already exists
-                    throw new ArgumentException("An item with the same key has already been added", "key");
+                    throw new ArgumentException("An item with the same key has already been added", nameof(key));
                 }
-                int oldLength = values.Length;
+                var oldLength = values.Length;
                 if (oldLength <= index)
                 {
                     // we'll assume they're doing lots of things, and
                     // grow it to the full width of the table
                     Array.Resize(ref values, table.FieldCount);
-                    for (int i = oldLength; i < values.Length; i++)
+                    for (var i = oldLength; i < values.Length; i++)
                     {
                         values[i] = DeadValue.Default;
                     }
@@ -204,14 +236,19 @@ namespace Dapper
 
             ICollection<string> IDictionary<string, object>.Keys
             {
-                get { return this.Select(kv => kv.Key).ToArray(); }
+                get
+                {
+                    return this.Select(kv => kv.Key).ToArray();
+                }
             }
 
             ICollection<object> IDictionary<string, object>.Values
             {
-                get { return this.Select(kv => kv.Value).ToArray(); }
+                get
+                {
+                    return this.Select(kv => kv.Value).ToArray();
+                }
             }
-
             #endregion
         }
     }

--- a/Dapper/SqlMapper.DapperRowMetaObject.cs
+++ b/Dapper/SqlMapper.DapperRowMetaObject.cs
@@ -1,53 +1,55 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq.Expressions;
 using System.Reflection;
+
 namespace Dapper
 {
     partial class SqlMapper
     {
-        sealed class DapperRowMetaObject : System.Dynamic.DynamicMetaObject
+        private sealed class DapperRowMetaObject : DynamicMetaObject
         {
-            static readonly MethodInfo getValueMethod = typeof(IDictionary<string, object>).GetProperty("Item").GetGetMethod();
-            static readonly MethodInfo setValueMethod = typeof(DapperRow).GetMethod("SetValue", new Type[] { typeof(string), typeof(object) });
+            private static readonly MethodInfo getValueMethod = typeof(IDictionary<string, object>).GetProperty("Item").GetGetMethod();
+            private static readonly MethodInfo setValueMethod = typeof(DapperRow).GetMethod("SetValue", new[] { typeof(string), typeof(object) });
 
             public DapperRowMetaObject(
-                System.Linq.Expressions.Expression expression,
-                System.Dynamic.BindingRestrictions restrictions
+                Expression expression,
+                BindingRestrictions restrictions
                 )
                 : base(expression, restrictions)
             {
             }
 
             public DapperRowMetaObject(
-                System.Linq.Expressions.Expression expression,
-                System.Dynamic.BindingRestrictions restrictions,
+                Expression expression,
+                BindingRestrictions restrictions,
                 object value
                 )
                 : base(expression, restrictions, value)
             {
             }
 
-            System.Dynamic.DynamicMetaObject CallMethod(
+            private DynamicMetaObject CallMethod(
                 MethodInfo method,
-                System.Linq.Expressions.Expression[] parameters
+                Expression[] parameters
                 )
             {
-                var callMethod = new System.Dynamic.DynamicMetaObject(
-                    System.Linq.Expressions.Expression.Call(
-                        System.Linq.Expressions.Expression.Convert(Expression, LimitType),
+                var callMethod = new DynamicMetaObject(
+                    Expression.Call(
+                        Expression.Convert(Expression, LimitType),
                         method,
                         parameters),
-                    System.Dynamic.BindingRestrictions.GetTypeRestriction(Expression, LimitType)
+                    BindingRestrictions.GetTypeRestriction(Expression, LimitType)
                     );
                 return callMethod;
             }
 
-            public override System.Dynamic.DynamicMetaObject BindGetMember(System.Dynamic.GetMemberBinder binder)
+            public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
             {
-                var parameters = new System.Linq.Expressions.Expression[]
-                                     {
-                                         System.Linq.Expressions.Expression.Constant(binder.Name)
-                                     };
+                var parameters = new Expression[]
+                                 {
+                                     Expression.Constant(binder.Name)
+                                 };
 
                 var callMethod = CallMethod(getValueMethod, parameters);
 
@@ -55,25 +57,25 @@ namespace Dapper
             }
 
             // Needed for Visual basic dynamic support
-            public override System.Dynamic.DynamicMetaObject BindInvokeMember(System.Dynamic.InvokeMemberBinder binder, System.Dynamic.DynamicMetaObject[] args)
+            public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
             {
-                var parameters = new System.Linq.Expressions.Expression[]
-                                     {
-                                         System.Linq.Expressions.Expression.Constant(binder.Name)
-                                     };
+                var parameters = new Expression[]
+                                 {
+                                     Expression.Constant(binder.Name)
+                                 };
 
                 var callMethod = CallMethod(getValueMethod, parameters);
 
                 return callMethod;
             }
 
-            public override System.Dynamic.DynamicMetaObject BindSetMember(System.Dynamic.SetMemberBinder binder, System.Dynamic.DynamicMetaObject value)
+            public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
             {
-                var parameters = new System.Linq.Expressions.Expression[]
-                                     {
-                                         System.Linq.Expressions.Expression.Constant(binder.Name),
-                                         value.Expression,
-                                     };
+                var parameters = new[]
+                                 {
+                                     Expression.Constant(binder.Name),
+                                     value.Expression
+                                 };
 
                 var callMethod = CallMethod(setValueMethod, parameters);
 

--- a/Dapper/SqlMapper.DataTable.cs
+++ b/Dapper/SqlMapper.DataTable.cs
@@ -7,22 +7,28 @@ namespace Dapper
     {
         private sealed class DapperTable
         {
-            string[] fieldNames;
-            readonly Dictionary<string, int> fieldNameLookup;
+            private string[] fieldNames;
+            private readonly Dictionary<string, int> fieldNameLookup;
 
-            internal string[] FieldNames { get { return fieldNames; } }
+            internal string[] FieldNames => fieldNames;
 
             public DapperTable(string[] fieldNames)
             {
-                if (fieldNames == null) throw new ArgumentNullException("fieldNames");
+                if (fieldNames == null)
+                {
+                    throw new ArgumentNullException(nameof(fieldNames));
+                }
                 this.fieldNames = fieldNames;
 
                 fieldNameLookup = new Dictionary<string, int>(fieldNames.Length, StringComparer.Ordinal);
                 // if there are dups, we want the **first** key to be the "winner" - so iterate backwards
-                for (int i = fieldNames.Length - 1; i >= 0; i--)
+                for (var i = fieldNames.Length - 1; i >= 0; i--)
                 {
-                    string key = fieldNames[i];
-                    if (key != null) fieldNameLookup[key] = i;
+                    var key = fieldNames[i];
+                    if (key != null)
+                    {
+                        fieldNameLookup[key] = i;
+                    }
                 }
             }
 
@@ -31,25 +37,30 @@ namespace Dapper
                 int result;
                 return (name != null && fieldNameLookup.TryGetValue(name, out result)) ? result : -1;
             }
+
             internal int AddField(string name)
             {
-                if (name == null) throw new ArgumentNullException("name");
-                if (fieldNameLookup.ContainsKey(name)) throw new InvalidOperationException("Field already exists: " + name);
-                int oldLen = fieldNames.Length;
+                if (name == null)
+                {
+                    throw new ArgumentNullException(nameof(name));
+                }
+                if (fieldNameLookup.ContainsKey(name))
+                {
+                    throw new InvalidOperationException("Field already exists: " + name);
+                }
+                var oldLen = fieldNames.Length;
                 Array.Resize(ref fieldNames, oldLen + 1); // yes, this is sub-optimal, but this is not the expected common case
                 fieldNames[oldLen] = name;
                 fieldNameLookup[name] = oldLen;
                 return oldLen;
             }
 
-
             internal bool FieldExists(string key)
             {
                 return key != null && fieldNameLookup.ContainsKey(key);
             }
 
-            public int FieldCount { get { return fieldNames.Length; } }
+            public int FieldCount => fieldNames.Length;
         }
-
     }
 }

--- a/Dapper/SqlMapper.DeserializerState.cs
+++ b/Dapper/SqlMapper.DeserializerState.cs
@@ -18,7 +18,7 @@ namespace Dapper
 {
     partial class SqlMapper
     {
-        struct DeserializerState
+        private struct DeserializerState
         {
             public readonly int Hash;
             public readonly Func<IDataReader, object> Func;

--- a/Dapper/SqlMapper.DontMap.cs
+++ b/Dapper/SqlMapper.DontMap.cs
@@ -5,6 +5,8 @@
         /// <summary>
         /// Dummy type for excluding from multi-map
         /// </summary>
-        class DontMap { }
+        private class DontMap
+        {
+        }
     }
 }

--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -20,20 +20,18 @@ namespace Dapper
 {
     partial class SqlMapper
     {
-
         /// <summary>
-        /// The grid reader provides interfaces for reading multiple result sets from a Dapper query 
+        /// The grid reader provides interfaces for reading multiple result sets from a Dapper query
         /// </summary>
         public partial class GridReader : IDisposable
         {
             private IDataReader reader;
-            private IDbCommand command;
-            private Identity identity;
-            private bool addToCache;
+            private readonly Identity identity;
+            private readonly bool addToCache;
 
-            internal GridReader(IDbCommand command, IDataReader reader, Identity identity, SqlMapper.IParameterCallbacks callbacks, bool addToCache)
+            internal GridReader(IDbCommand command, IDataReader reader, Identity identity, IParameterCallbacks callbacks, bool addToCache)
             {
-                this.Command = command;
+                Command = command;
                 this.reader = reader;
                 this.identity = identity;
                 this.callbacks = callbacks;
@@ -62,44 +60,53 @@ namespace Dapper
             /// </summary>
             public IEnumerable<object> Read(Type type, bool buffered = true)
             {
-                if (type == null) throw new ArgumentNullException("type");
+                if (type == null)
+                {
+                    throw new ArgumentNullException(nameof(type));
+                }
                 return ReadImpl<object>(type, buffered);
             }
 
             private IEnumerable<T> ReadImpl<T>(Type type, bool buffered)
             {
-                if (reader == null) throw new ObjectDisposedException(GetType().FullName, "The reader has been disposed; this can happen after all data has been consumed");
-                if (consumed) throw new InvalidOperationException("Query results must be consumed in the correct order, and each result can only be consumed once");
+                if (reader == null)
+                {
+                    throw new ObjectDisposedException(GetType().FullName, "The reader has been disposed; this can happen after all data has been consumed");
+                }
+                if (IsConsumed)
+                {
+                    throw new InvalidOperationException("Query results must be consumed in the correct order, and each result can only be consumed once");
+                }
                 var typedIdentity = identity.ForGrid(type, gridIndex);
-                CacheInfo cache = GetCacheInfo(typedIdentity, null, addToCache);
+                var cache = GetCacheInfo(typedIdentity, null, addToCache);
                 var deserializer = cache.Deserializer;
 
-                int hash = GetColumnHash(reader);
+                var hash = GetColumnHash(reader);
                 if (deserializer.Func == null || deserializer.Hash != hash)
                 {
                     deserializer = new DeserializerState(hash, GetDeserializer(type, reader, 0, -1, false));
                     cache.Deserializer = deserializer;
                 }
-                consumed = true;
+                IsConsumed = true;
                 var result = ReadDeferred<T>(gridIndex, deserializer.Func, typedIdentity);
                 return buffered ? result.ToList() : result;
             }
 
-
             private IEnumerable<TReturn> MultiReadInternal<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(Delegate func, string splitOn)
             {
-                var identity = this.identity.ForGrid(typeof(TReturn), new Type[] {
-                    typeof(TFirst),
-                    typeof(TSecond),
-                    typeof(TThird),
-                    typeof(TFourth),
-                    typeof(TFifth),
-                    typeof(TSixth),
-                    typeof(TSeventh)
-                }, gridIndex);
+                var identity = this.identity.ForGrid(typeof(TReturn), new[]
+                                                                      {
+                                                                          typeof(TFirst),
+                                                                          typeof(TSecond),
+                                                                          typeof(TThird),
+                                                                          typeof(TFourth),
+                                                                          typeof(TFifth),
+                                                                          typeof(TSixth),
+                                                                          typeof(TSeventh)
+                                                                      }, gridIndex);
                 try
                 {
-                    foreach (var r in SqlMapper.MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, default(CommandDefinition), func, splitOn, reader, identity, false))
+                    foreach (var r in MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, default(CommandDefinition), func, splitOn, reader, identity, false))
                     {
                         yield return r;
                     }
@@ -115,7 +122,7 @@ namespace Dapper
                 var identity = this.identity.ForGrid(typeof(TReturn), types, gridIndex);
                 try
                 {
-                    foreach (var r in SqlMapper.MultiMapImpl<TReturn>(null, default(CommandDefinition), types, map, splitOn, reader, identity, false))
+                    foreach (var r in MultiMapImpl(null, default(CommandDefinition), types, map, splitOn, reader, identity, false))
                     {
                         yield return r;
                     }
@@ -161,6 +168,7 @@ namespace Dapper
                 var result = MultiReadInternal<TFirst, TSecond, TThird, TFourth, TFifth, DontMap, DontMap, TReturn>(func, splitOn);
                 return buffered ? result.ToList() : result;
             }
+
             /// <summary>
             /// Read multiple objects from a single record set on the grid
             /// </summary>
@@ -169,6 +177,7 @@ namespace Dapper
                 var result = MultiReadInternal<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, DontMap, TReturn>(func, splitOn);
                 return buffered ? result.ToList() : result;
             }
+
             /// <summary>
             /// Read multiple objects from a single record set on the grid
             /// </summary>
@@ -183,7 +192,7 @@ namespace Dapper
             /// </summary>
             public IEnumerable<TReturn> Read<TReturn>(Type[] types, Func<object[], TReturn> map, string splitOn = "id", bool buffered = true)
             {
-                var result = MultiReadInternal<TReturn>(types, map, splitOn);
+                var result = MultiReadInternal(types, map, splitOn);
                 return buffered ? result.ToList() : result;
             }
 
@@ -204,35 +213,19 @@ namespace Dapper
                     }
                 }
             }
+
             private int gridIndex, readCount;
-            private bool consumed;
-            private SqlMapper.IParameterCallbacks callbacks;
+            private readonly IParameterCallbacks callbacks;
 
             /// <summary>
             /// Has the underlying reader been consumed?
             /// </summary>
-            public bool IsConsumed
-            {
-                get
-                {
-                    return consumed;
-                }
-            }
+            public bool IsConsumed { get; private set; }
+
             /// <summary>
             /// The command associated with the reader
             /// </summary>
-            public IDbCommand Command
-            {
-                get
-                {
-                    return command;
-                }
-
-                set
-                {
-                    command = value;
-                }
-            }
+            public IDbCommand Command { get; set; }
 
             private void NextResult()
             {
@@ -240,7 +233,7 @@ namespace Dapper
                 {
                     readCount++;
                     gridIndex++;
-                    consumed = false;
+                    IsConsumed = false;
                 }
                 else
                 {
@@ -248,10 +241,11 @@ namespace Dapper
                     // need for "Cancel" etc
                     reader.Dispose();
                     reader = null;
-                    if (callbacks != null) callbacks.OnCompleted();
+                    callbacks?.OnCompleted();
                     Dispose();
                 }
             }
+
             /// <summary>
             /// Dispose the grid, closing and disposing both the underlying reader and command.
             /// </summary>
@@ -259,7 +253,10 @@ namespace Dapper
             {
                 if (reader != null)
                 {
-                    if (!reader.IsClosed && Command != null) Command.Cancel();
+                    if (!reader.IsClosed)
+                    {
+                        Command?.Cancel();
+                    }
                     reader.Dispose();
                     reader = null;
                 }

--- a/Dapper/SqlMapper.ICustomQueryParameter.cs
+++ b/Dapper/SqlMapper.ICustomQueryParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -11,6 +12,7 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     partial class SqlMapper

--- a/Dapper/SqlMapper.IMemberMap.cs
+++ b/Dapper/SqlMapper.IMemberMap.cs
@@ -16,7 +16,7 @@ namespace Dapper
             string ColumnName { get; }
 
             /// <summary>
-            ///  Target member type
+            /// Target member type
             /// </summary>
             Type MemberType { get; }
 
@@ -35,6 +35,5 @@ namespace Dapper
             /// </summary>
             ParameterInfo Parameter { get; }
         }
-
     }
 }

--- a/Dapper/SqlMapper.IParameterCallbacks.cs
+++ b/Dapper/SqlMapper.IParameterCallbacks.cs
@@ -2,7 +2,6 @@
 {
     partial class SqlMapper
     {
-
         /// <summary>
         /// Extends IDynamicParameters with facilities for executing callbacks after commands have completed
         /// </summary>
@@ -13,6 +12,5 @@
             /// </summary>
             void OnCompleted();
         }
-
     }
 }

--- a/Dapper/SqlMapper.ITypeHandler.cs
+++ b/Dapper/SqlMapper.ITypeHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -12,6 +13,7 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     partial class SqlMapper

--- a/Dapper/SqlMapper.ITypeMap.cs
+++ b/Dapper/SqlMapper.ITypeMap.cs
@@ -20,9 +20,7 @@ namespace Dapper
 
             /// <summary>
             /// Returns a constructor which should *always* be used.
-            /// 
             /// Parameters will be default values, nulls for reference types and zero'd for value types.
-            /// 
             /// Use this class to force object creation away from parameterless constructors you don't control.
             /// </summary>
             ConstructorInfo FindExplicitConstructor();
@@ -42,6 +40,5 @@ namespace Dapper
             /// <returns>Mapping implementation</returns>
             IMemberMap GetMember(string columnName);
         }
-
     }
 }

--- a/Dapper/SqlMapper.Identity.cs
+++ b/Dapper/SqlMapper.Identity.cs
@@ -32,6 +32,7 @@ namespace Dapper
             {
                 return new Identity(sql, commandType, connectionString, primaryType, parametersType, otherTypes, gridIndex);
             }
+
             /// <summary>
             /// Create an identity for use with DynamicParameters, internal use only
             /// </summary>
@@ -44,7 +45,9 @@ namespace Dapper
 
             internal Identity(string sql, CommandType? commandType, IDbConnection connection, Type type, Type parametersType, Type[] otherTypes)
                 : this(sql, commandType, connection.ConnectionString, type, parametersType, otherTypes, 0)
-            { }
+            {
+            }
+
             private Identity(string sql, CommandType? commandType, string connectionString, Type type, Type parametersType, Type[] otherTypes, int gridIndex)
             {
                 this.sql = sql;
@@ -58,22 +61,21 @@ namespace Dapper
                     hashCode = 17; // we *know* we are using this in a dictionary, so pre-compute this
                     hashCode = hashCode * 23 + commandType.GetHashCode();
                     hashCode = hashCode * 23 + gridIndex.GetHashCode();
-                    hashCode = hashCode * 23 + (sql == null ? 0 : sql.GetHashCode());
-                    hashCode = hashCode * 23 + (type == null ? 0 : type.GetHashCode());
+                    hashCode = hashCode * 23 + (sql?.GetHashCode() ?? 0);
+                    hashCode = hashCode * 23 + (type?.GetHashCode() ?? 0);
                     if (otherTypes != null)
                     {
                         foreach (var t in otherTypes)
                         {
-                            hashCode = hashCode * 23 + (t == null ? 0 : t.GetHashCode());
+                            hashCode = hashCode * 23 + (t?.GetHashCode() ?? 0);
                         }
                     }
-                    hashCode = hashCode * 23 + (connectionString == null ? 0 : SqlMapper.connectionStringComparer.GetHashCode(connectionString));
-                    hashCode = hashCode * 23 + (parametersType == null ? 0 : parametersType.GetHashCode());
+                    hashCode = hashCode * 23 + (connectionString == null ? 0 : connectionStringComparer.GetHashCode(connectionString));
+                    hashCode = hashCode * 23 + (parametersType?.GetHashCode() ?? 0);
                 }
             }
 
             /// <summary>
-            /// 
             /// </summary>
             /// <param name="obj"></param>
             /// <returns></returns>
@@ -81,39 +83,41 @@ namespace Dapper
             {
                 return Equals(obj as Identity);
             }
+
             /// <summary>
             /// The sql
             /// </summary>
             public readonly string sql;
+
             /// <summary>
-            /// The command type 
+            /// The command type
             /// </summary>
             public readonly CommandType? commandType;
 
             /// <summary>
-            /// 
             /// </summary>
             public readonly int hashCode, gridIndex;
+
             /// <summary>
-            /// 
             /// </summary>
             public readonly Type type;
+
             /// <summary>
-            /// 
             /// </summary>
             public readonly string connectionString;
+
             /// <summary>
-            /// 
             /// </summary>
             public readonly Type parametersType;
+
             /// <summary>
-            /// 
             /// </summary>
             /// <returns></returns>
             public override int GetHashCode()
             {
                 return hashCode;
             }
+
             /// <summary>
             /// Compare 2 Identity objects
             /// </summary>
@@ -127,7 +131,7 @@ namespace Dapper
                     type == other.type &&
                     sql == other.sql &&
                     commandType == other.commandType &&
-                    SqlMapper.connectionStringComparer.Equals(connectionString, other.connectionString) &&
+                    connectionStringComparer.Equals(connectionString, other.connectionString) &&
                     parametersType == other.parametersType;
             }
         }

--- a/Dapper/SqlMapper.Link.cs
+++ b/Dapper/SqlMapper.Link.cs
@@ -15,7 +15,7 @@ namespace Dapper
             {
                 while (link != null)
                 {
-                    if ((object)key == (object)link.Key)
+                    if (key == link.Key)
                     {
                         value = link.Value;
                         return true;
@@ -25,6 +25,7 @@ namespace Dapper
                 value = default(TValue);
                 return false;
             }
+
             public static bool TryAdd(ref Link<TKey, TValue> head, TKey key, ref TValue value)
             {
                 bool tryAgain;
@@ -33,7 +34,8 @@ namespace Dapper
                     var snapshot = Interlocked.CompareExchange(ref head, null, null);
                     TValue found;
                     if (TryGet(snapshot, key, out found))
-                    { // existing match; report the existing value instead
+                    {
+                        // existing match; report the existing value instead
                         value = found;
                         return false;
                     }
@@ -43,15 +45,19 @@ namespace Dapper
                 } while (tryAgain);
                 return true;
             }
+
             private Link(TKey key, TValue value, Link<TKey, TValue> tail)
             {
                 Key = key;
                 Value = value;
                 Tail = tail;
             }
-            public TKey Key { get; private set; }
-            public TValue Value { get; private set; }
-            public Link<TKey, TValue> Tail { get; private set; }
+
+            public TKey Key { get; }
+
+            public TValue Value { get; }
+
+            public Link<TKey, TValue> Tail { get; }
         }
     }
 }

--- a/Dapper/SqlMapper.LiteralToken.cs
+++ b/Dapper/SqlMapper.LiteralToken.cs
@@ -9,20 +9,20 @@ namespace Dapper
         /// </summary>
         internal struct LiteralToken
         {
-            private readonly string token, member;
             /// <summary>
             /// The text in the original command that should be replaced
             /// </summary>
-            public string Token { get { return token; } }
+            public string Token { get; }
 
             /// <summary>
             /// The name of the member referred to by the token
             /// </summary>
-            public string Member { get { return member; } }
+            public string Member { get; }
+
             internal LiteralToken(string token, string member)
             {
-                this.token = token;
-                this.member = member;
+                Token = token;
+                Member = member;
             }
 
             internal static readonly IList<LiteralToken> None = new LiteralToken[0];

--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -25,6 +25,5 @@
             /// </summary>
             public static int? CommandTimeout { get; set; }
         }
-
     }
 }

--- a/Dapper/SqlMapper.TypeHandler.cs
+++ b/Dapper/SqlMapper.TypeHandler.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -15,6 +13,7 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     partial class SqlMapper
@@ -55,6 +54,5 @@ namespace Dapper
                 return Parse(value);
             }
         }
-
     }
 }

--- a/Dapper/SqlMapper.TypeHandlerCache.cs
+++ b/Dapper/SqlMapper.TypeHandlerCache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Data;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -13,6 +14,7 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     partial class SqlMapper
@@ -34,7 +36,6 @@ namespace Dapper
             public static T Parse(object value)
             {
                 return (T)handler.Parse(typeof(T), value);
-
             }
 
             /// <summary>

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1,5 +1,5 @@
 /*
- License: http://www.apache.org/licenses/LICENSE-2.0 
+ License: http://www.apache.org/licenses/LICENSE-2.0
  Home page: http://code.google.com/p/dapper-dot-net/
  */
 
@@ -44,10 +44,10 @@ namespace Dapper
             unchecked
             {
                 int colCount = reader.FieldCount, hash = colCount;
-                for (int i = 0; i < colCount; i++)
+                for (var i = 0; i < colCount; i++)
                 {   // binding code is only interested in names - not types
                     object tmp = reader.GetName(i);
-                    hash = (hash * 31) + (tmp == null ? 0 : tmp.GetHashCode());
+                    hash = (hash * 31) + (tmp?.GetHashCode() ?? 0);
                 }
                 return hash;
             }
@@ -61,7 +61,7 @@ namespace Dapper
         private static void OnQueryCachePurged()
         {
             var handler = QueryCachePurged;
-            if (handler != null) handler(null, EventArgs.Empty);
+            handler?.Invoke(null, EventArgs.Empty);
         }
 
         static readonly System.Collections.Concurrent.ConcurrentDictionary<Identity, CacheInfo> _queryCache = new System.Collections.Concurrent.ConcurrentDictionary<Identity, CacheInfo>();
@@ -108,7 +108,7 @@ namespace Dapper
         }
 
         /// <summary>
-        /// Purge the query cache 
+        /// Purge the query cache
         /// </summary>
         public static void PurgeQueryCache()
         {
@@ -177,44 +177,46 @@ namespace Dapper
 
         static SqlMapper()
         {
-            typeMap = new Dictionary<Type, DbType>();
-            typeMap[typeof(byte)] = DbType.Byte;
-            typeMap[typeof(sbyte)] = DbType.SByte;
-            typeMap[typeof(short)] = DbType.Int16;
-            typeMap[typeof(ushort)] = DbType.UInt16;
-            typeMap[typeof(int)] = DbType.Int32;
-            typeMap[typeof(uint)] = DbType.UInt32;
-            typeMap[typeof(long)] = DbType.Int64;
-            typeMap[typeof(ulong)] = DbType.UInt64;
-            typeMap[typeof(float)] = DbType.Single;
-            typeMap[typeof(double)] = DbType.Double;
-            typeMap[typeof(decimal)] = DbType.Decimal;
-            typeMap[typeof(bool)] = DbType.Boolean;
-            typeMap[typeof(string)] = DbType.String;
-            typeMap[typeof(char)] = DbType.StringFixedLength;
-            typeMap[typeof(Guid)] = DbType.Guid;
-            typeMap[typeof(DateTime)] = DbType.DateTime;
-            typeMap[typeof(DateTimeOffset)] = DbType.DateTimeOffset;
-            typeMap[typeof(TimeSpan)] = DbType.Time;
-            typeMap[typeof(byte[])] = DbType.Binary;
-            typeMap[typeof(byte?)] = DbType.Byte;
-            typeMap[typeof(sbyte?)] = DbType.SByte;
-            typeMap[typeof(short?)] = DbType.Int16;
-            typeMap[typeof(ushort?)] = DbType.UInt16;
-            typeMap[typeof(int?)] = DbType.Int32;
-            typeMap[typeof(uint?)] = DbType.UInt32;
-            typeMap[typeof(long?)] = DbType.Int64;
-            typeMap[typeof(ulong?)] = DbType.UInt64;
-            typeMap[typeof(float?)] = DbType.Single;
-            typeMap[typeof(double?)] = DbType.Double;
-            typeMap[typeof(decimal?)] = DbType.Decimal;
-            typeMap[typeof(bool?)] = DbType.Boolean;
-            typeMap[typeof(char?)] = DbType.StringFixedLength;
-            typeMap[typeof(Guid?)] = DbType.Guid;
-            typeMap[typeof(DateTime?)] = DbType.DateTime;
-            typeMap[typeof(DateTimeOffset?)] = DbType.DateTimeOffset;
-            typeMap[typeof(TimeSpan?)] = DbType.Time;
-            typeMap[typeof(object)] = DbType.Object;
+            typeMap = new Dictionary<Type, DbType>
+                      {
+                          [typeof(byte)] = DbType.Byte,
+                          [typeof(sbyte)] = DbType.SByte,
+                          [typeof(short)] = DbType.Int16,
+                          [typeof(ushort)] = DbType.UInt16,
+                          [typeof(int)] = DbType.Int32,
+                          [typeof(uint)] = DbType.UInt32,
+                          [typeof(long)] = DbType.Int64,
+                          [typeof(ulong)] = DbType.UInt64,
+                          [typeof(float)] = DbType.Single,
+                          [typeof(double)] = DbType.Double,
+                          [typeof(decimal)] = DbType.Decimal,
+                          [typeof(bool)] = DbType.Boolean,
+                          [typeof(string)] = DbType.String,
+                          [typeof(char)] = DbType.StringFixedLength,
+                          [typeof(Guid)] = DbType.Guid,
+                          [typeof(DateTime)] = DbType.DateTime,
+                          [typeof(DateTimeOffset)] = DbType.DateTimeOffset,
+                          [typeof(TimeSpan)] = DbType.Time,
+                          [typeof(byte[])] = DbType.Binary,
+                          [typeof(byte?)] = DbType.Byte,
+                          [typeof(sbyte?)] = DbType.SByte,
+                          [typeof(short?)] = DbType.Int16,
+                          [typeof(ushort?)] = DbType.UInt16,
+                          [typeof(int?)] = DbType.Int32,
+                          [typeof(uint?)] = DbType.UInt32,
+                          [typeof(long?)] = DbType.Int64,
+                          [typeof(ulong?)] = DbType.UInt64,
+                          [typeof(float?)] = DbType.Single,
+                          [typeof(double?)] = DbType.Double,
+                          [typeof(decimal?)] = DbType.Decimal,
+                          [typeof(bool?)] = DbType.Boolean,
+                          [typeof(char?)] = DbType.StringFixedLength,
+                          [typeof(Guid?)] = DbType.Guid,
+                          [typeof(DateTime?)] = DbType.DateTime,
+                          [typeof(DateTimeOffset?)] = DbType.DateTimeOffset,
+                          [typeof(TimeSpan?)] = DbType.Time,
+                          [typeof(object)] = DbType.Object
+                      };
 #if !DNXCORE50
             AddTypeHandlerImpl(typeof(DataTable), new DataTableHandler(), false);
             AddTypeHandlerImpl(typeof(IEnumerable<Microsoft.SqlServer.Server.SqlDataRecord>), new SqlDataRecordHandler(), false);
@@ -243,8 +245,7 @@ namespace Dapper
             DbType oldValue;
             if (snapshot.TryGetValue(type, out oldValue) && oldValue == dbType) return; // nothing to do
 
-            var newCopy = new Dictionary<Type, DbType>(snapshot);
-            newCopy[type] = dbType;
+            var newCopy = new Dictionary<Type, DbType>(snapshot) { [type] = dbType };
             typeMap = newCopy;
         }
 
@@ -261,7 +262,7 @@ namespace Dapper
         /// </summary>
         public static void AddTypeHandlerImpl(Type type, ITypeHandler handler, bool clone)
         {
-            if (type == null) throw new ArgumentNullException("type");
+            if (type == null) throw new ArgumentNullException(nameof(type));
 
             Type secondary = null;
             if(type.IsValueType())
@@ -377,7 +378,7 @@ namespace Dapper
             }
 #endif
             if(demand)
-                throw new NotSupportedException(string.Format("The member {0} of type {1} cannot be used as a parameter value", name, type.FullName));
+                throw new NotSupportedException($"The member {name} of type {type.FullName} cannot be used as a parameter value");
             return DbType.Object;
 
         }
@@ -394,7 +395,7 @@ namespace Dapper
         }
 
         /// <summary>
-        /// Execute parameterized SQL  
+        /// Execute parameterized SQL
         /// </summary>
         /// <returns>Number of rows affected</returns>
         public static int Execute(
@@ -405,7 +406,7 @@ namespace Dapper
             return ExecuteImpl(cnn, ref command);
         }
         /// <summary>
-        /// Execute parameterized SQL  
+        /// Execute parameterized SQL
         /// </summary>
         /// <returns>Number of rows affected</returns>
         public static int Execute(this IDbConnection cnn, CommandDefinition command)
@@ -467,8 +468,8 @@ namespace Dapper
 
         private static int ExecuteImpl(this IDbConnection cnn, ref CommandDefinition command)
         {
-            object param = command.Parameters;
-            IEnumerable multiExec = GetMultiExec(param);
+            var param = command.Parameters;
+            var multiExec = GetMultiExec(param);
             Identity identity;
             CacheInfo info = null;
             if (multiExec != null)
@@ -480,9 +481,9 @@ namespace Dapper
                     return ExecuteMultiImplAsync(cnn, command, multiExec).Result;
                 }
 #endif
-                bool isFirst = true;
-                int total = 0;
-                bool wasClosed = cnn.State == ConnectionState.Closed;
+                var isFirst = true;
+                var total = 0;
+                var wasClosed = cnn.State == ConnectionState.Closed;
                 try
                 {
                     if (wasClosed) cnn.Open();
@@ -617,7 +618,7 @@ namespace Dapper
             this IDbConnection cnn, Type type, string sql, object param = null, IDbTransaction transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null
         )
         {
-            if (type == null) throw new ArgumentNullException("type");
+            if (type == null) throw new ArgumentNullException(nameof(type));
             var command = new CommandDefinition(sql, (object)param, transaction, commandTimeout, commandType, buffered ? CommandFlags.Buffered : CommandFlags.None);
             var data = QueryImpl<object>(cnn, command, type);
             return command.Buffered ? data.ToList() : data;
@@ -656,13 +657,13 @@ namespace Dapper
         }
         private static GridReader QueryMultipleImpl(this IDbConnection cnn, ref CommandDefinition command)
         {
-            object param = command.Parameters;
-            Identity identity = new Identity(command.CommandText, command.CommandType, cnn, typeof(GridReader), param == null ? null : param.GetType(), null);
-            CacheInfo info = GetCacheInfo(identity, param, command.AddToCache);
+            var param = command.Parameters;
+            var identity = new Identity(command.CommandText, command.CommandType, cnn, typeof(GridReader), param?.GetType(), null);
+            var info = GetCacheInfo(identity, param, command.AddToCache);
 
             IDbCommand cmd = null;
             IDataReader reader = null;
-            bool wasClosed = cnn.State == ConnectionState.Closed;
+            var wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
                 if (wasClosed) cnn.Open();
@@ -693,14 +694,14 @@ namespace Dapper
 
         private static IEnumerable<T> QueryImpl<T>(this IDbConnection cnn, CommandDefinition command, Type effectiveType)
         {
-            object param = command.Parameters;
-            var identity = new Identity(command.CommandText, command.CommandType, cnn, effectiveType, param == null ? null : param.GetType(), null);
+            var param = command.Parameters;
+            var identity = new Identity(command.CommandText, command.CommandType, cnn, effectiveType, param?.GetType(), null);
             var info = GetCacheInfo(identity, param, command.AddToCache);
 
             IDbCommand cmd = null;
             IDataReader reader = null;
 
-            bool wasClosed = cnn.State == ConnectionState.Closed;
+            var wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
                 cmd = command.SetupCommand(cnn, info.ParamReader);
@@ -712,7 +713,7 @@ namespace Dapper
                 // still need something in the "finally" to ensure that broken SQL still results
                 // in the connection closing itself
                 var tuple = info.Deserializer;
-                int hash = GetColumnHash(reader);
+                var hash = GetColumnHash(reader);
                 if (tuple.Func == null || tuple.Hash != hash)
                 {
                     if (reader.FieldCount == 0) //https://code.google.com/p/dapper-dot-net/issues/detail?id=57
@@ -725,7 +726,7 @@ namespace Dapper
                 var convertToType = Nullable.GetUnderlyingType(effectiveType) ?? effectiveType;
                 while (reader.Read())
                 {
-                    object val = func(reader);
+                    var val = func(reader);
 					if (val == null || val is T) {
                         yield return (T)val;
                     } else {
@@ -749,7 +750,7 @@ namespace Dapper
                     reader.Dispose();
                 }
                 if (wasClosed) cnn.Close();
-                if (cmd != null) cmd.Dispose();
+                cmd?.Dispose();
             }
         }
 
@@ -937,14 +938,14 @@ namespace Dapper
 
         static IEnumerable<TReturn> MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDbConnection cnn, CommandDefinition command, Delegate map, string splitOn, IDataReader reader, Identity identity, bool finalize)
         {
-            object param = command.Parameters;
+            var param = command.Parameters;
             identity = identity ?? new Identity(command.CommandText, command.CommandType, cnn, typeof(TFirst), param == null ? null : param.GetType(), new[] { typeof(TFirst), typeof(TSecond), typeof(TThird), typeof(TFourth), typeof(TFifth), typeof(TSixth), typeof(TSeventh) });
-            CacheInfo cinfo = GetCacheInfo(identity, param, command.AddToCache);
+            var cinfo = GetCacheInfo(identity, param, command.AddToCache);
 
             IDbCommand ownedCommand = null;
             IDataReader ownedReader = null;
 
-            bool wasClosed = cnn != null && cnn.State == ConnectionState.Closed;
+            var wasClosed = cnn != null && cnn.State == ConnectionState.Closed;
             try
             {
                 if (reader == null)
@@ -954,19 +955,19 @@ namespace Dapper
                     ownedReader = ownedCommand.ExecuteReader(wasClosed ? CommandBehavior.CloseConnection | CommandBehavior.SequentialAccess : CommandBehavior.SequentialAccess);
                     reader = ownedReader;
                 }
-                DeserializerState deserializer = default(DeserializerState);
+                var deserializer = default(DeserializerState);
                 Func<IDataReader, object>[] otherDeserializers = null;
 
-                int hash = GetColumnHash(reader);
+                var hash = GetColumnHash(reader);
                 if ((deserializer = cinfo.Deserializer).Func == null || (otherDeserializers = cinfo.OtherDeserializers) == null || hash != deserializer.Hash)
                 {
-                    var deserializers = GenerateDeserializers(new Type[] { typeof(TFirst), typeof(TSecond), typeof(TThird), typeof(TFourth), typeof(TFifth), typeof(TSixth), typeof(TSeventh) }, splitOn, reader);
+                    var deserializers = GenerateDeserializers(new[] { typeof(TFirst), typeof(TSecond), typeof(TThird), typeof(TFourth), typeof(TFifth), typeof(TSixth), typeof(TSeventh) }, splitOn, reader);
                     deserializer = cinfo.Deserializer = new DeserializerState(hash, deserializers[0]);
                     otherDeserializers = cinfo.OtherDeserializers = deserializers.Skip(1).ToArray();
                     if(command.AddToCache) SetQueryCache(identity, cinfo);
                 }
 
-                Func<IDataReader, TReturn> mapIt = GenerateMapper<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(deserializer.Func, otherDeserializers, map);
+                var mapIt = GenerateMapper<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(deserializer.Func, otherDeserializers, map);
 
                 if (mapIt != null)
                 {
@@ -978,7 +979,7 @@ namespace Dapper
                     {
                         while (reader.NextResult()) { }
                         command.OnCompleted();
-                    }                    
+                    }
                 }
             }
             finally
@@ -1008,14 +1009,14 @@ namespace Dapper
                 throw new ArgumentException("you must provide at least one type to deserialize");
             }
 
-            object param = command.Parameters;
+            var param = command.Parameters;
             identity = identity ?? new Identity(command.CommandText, command.CommandType, cnn, types[0], param == null ? null : param.GetType(), types);
-            CacheInfo cinfo = GetCacheInfo(identity, param, command.AddToCache);
+            var cinfo = GetCacheInfo(identity, param, command.AddToCache);
 
             IDbCommand ownedCommand = null;
             IDataReader ownedReader = null;
 
-            bool wasClosed = cnn != null && cnn.State == ConnectionState.Closed;
+            var wasClosed = cnn != null && cnn.State == ConnectionState.Closed;
             try
             {
                 if (reader == null)
@@ -1025,10 +1026,10 @@ namespace Dapper
                     ownedReader = ownedCommand.ExecuteReader();
                     reader = ownedReader;
                 }
-                DeserializerState deserializer = default(DeserializerState);
+                var deserializer = default(DeserializerState);
                 Func<IDataReader, object>[] otherDeserializers = null;
 
-                int hash = GetColumnHash(reader);
+                var hash = GetColumnHash(reader);
                 if ((deserializer = cinfo.Deserializer).Func == null || (otherDeserializers = cinfo.OtherDeserializers) == null || hash != deserializer.Hash)
                 {
                     var deserializers = GenerateDeserializers(types, splitOn, reader);
@@ -1037,7 +1038,7 @@ namespace Dapper
                     SetQueryCache(identity, cinfo);
                 }
 
-                Func<IDataReader, TReturn> mapIt = GenerateMapper(types.Length, deserializer.Func, otherDeserializers, map);
+                var mapIt = GenerateMapper(types.Length, deserializer.Func, otherDeserializers, map);
 
                 if (mapIt != null)
                 {
@@ -1056,17 +1057,11 @@ namespace Dapper
             {
                 try
                 {
-                    if (ownedReader != null)
-                    {
-                        ownedReader.Dispose();
-                    }
+                    ownedReader?.Dispose();
                 }
                 finally
                 {
-                    if (ownedCommand != null)
-                    {
-                        ownedCommand.Dispose();
-                    }
+                    ownedCommand?.Dispose();
                     if (wasClosed) cnn.Close();
                 }
             }
@@ -1113,15 +1108,15 @@ namespace Dapper
         {
             var deserializers = new List<Func<IDataReader, object>>();
             var splits = splitOn.Split(',').Select(s => s.Trim()).ToArray();
-                bool isMultiSplit = splits.Length > 1;
-            if (types.First() == typeof(Object))
+            var isMultiSplit = splits.Length > 1;
+            if (types.First() == typeof(object))
             {
                 // we go left to right for dynamic multi-mapping so that the madness of TestMultiMappingVariations
                 // is supported
-                bool first = true;
-                int currentPos = 0;
-                int splitIdx = 0;
-                string currentSplit = splits[splitIdx];
+                var first = true;
+                var currentPos = 0;
+                var splitIdx = 0;
+                var currentSplit = splits[splitIdx];
                 foreach (var type in types)
                 {
                     if (type == typeof(DontMap))
@@ -1129,7 +1124,7 @@ namespace Dapper
                         break;
                     }
 
-                    int splitPoint = GetNextSplitDynamic(currentPos, currentSplit, reader);
+                    var splitPoint = GetNextSplitDynamic(currentPos, currentSplit, reader);
                     if (isMultiSplit && splitIdx < splits.Length - 1)
                     {
                         currentSplit = splits[++splitIdx];
@@ -1143,8 +1138,8 @@ namespace Dapper
             {
                 // in this we go right to left through the data reader in order to cope with properties that are
                 // named the same as a subsequent primary key that we split on
-                int currentPos = reader.FieldCount;
-                int splitIdx = splits.Length - 1;
+                var currentPos = reader.FieldCount;
+                var splitIdx = splits.Length - 1;
                 var currentSplit = splits[splitIdx];
                 for (var typeIdx = types.Length - 1; typeIdx >= 0; --typeIdx)
                 {
@@ -1154,7 +1149,7 @@ namespace Dapper
                         continue;
                     }
 
-                    int splitPoint = 0;
+                    var splitPoint = 0;
                     if (typeIdx > 0)
                     {
                         splitPoint = GetNextSplit(currentPos, currentSplit, reader);
@@ -1271,17 +1266,17 @@ namespace Dapper
         {
             if (cmd.Parameters.Count == 0) return;
 
-            Dictionary<string, IDbDataParameter> parameters = new Dictionary<string, IDbDataParameter>(StringComparer.Ordinal);
-            
+            var parameters = new Dictionary<string, IDbDataParameter>(StringComparer.Ordinal);
+
             foreach(IDbDataParameter param in cmd.Parameters)
             {
                 if (!string.IsNullOrEmpty(param.ParameterName)) parameters[param.ParameterName] = param;
             }
-            HashSet<string> consumed = new HashSet<string>(StringComparer.Ordinal);
-            bool firstMatch = true;
+            var consumed = new HashSet<string>(StringComparer.Ordinal);
+            var firstMatch = true;
             cmd.CommandText = pseudoPositional.Replace(cmd.CommandText, match =>
             {
-                string key = match.Groups[1].Value;
+                var key = match.Groups[1].Value;
                 IDbDataParameter param;
                 if (!consumed.Add(key))
                 {
@@ -1339,7 +1334,7 @@ namespace Dapper
 
         private static Exception MultiMapException(IDataRecord reader)
         {
-            bool hasFields = false;
+            var hasFields = false;
             try {
                 hasFields = reader != null && reader.FieldCount != 0;
             } catch { }
@@ -1348,7 +1343,7 @@ namespace Dapper
             else
                 return new InvalidOperationException("No columns were selected");
         }
-        
+
         internal static Func<IDataReader, object> GetDapperRowDeserializer(IDataRecord reader, int startBound, int length, bool returnNullIfFirstMissing)
         {
             var fieldCount = reader.FieldCount;
@@ -1371,8 +1366,8 @@ namespace Dapper
                 {
                     if (table == null)
                     {
-                        string[] names = new string[effectiveFieldCount];
-                        for (int i = 0; i < effectiveFieldCount; i++)
+                        var names = new string[effectiveFieldCount];
+                        for (var i = 0; i < effectiveFieldCount; i++)
                         {
                             names[i] = r.GetName(i + startBound);
                         }
@@ -1392,9 +1387,9 @@ namespace Dapper
 
                     if (startBound == 0)
                     {
-                        for (int i = 0; i < values.Length; i++)
+                        for (var i = 0; i < values.Length; i++)
                         {
-                            object val = r.GetValue(i);
+                            var val = r.GetValue(i);
                             values[i] = val is DBNull ? null : val;
                         }
                     }
@@ -1403,7 +1398,7 @@ namespace Dapper
                         var begin = returnNullIfFirstMissing ? 1 : 0;
                         for (var iter = begin; iter < effectiveFieldCount; ++iter)
                         {
-                            object obj = r.GetValue(iter + startBound);
+                            var obj = r.GetValue(iter + startBound);
                             values[iter] = obj is DBNull ? null : obj;
                         }
                     }
@@ -1422,9 +1417,9 @@ namespace Dapper
         [Obsolete("This method is for internal usage only", false)]
         public static char ReadChar(object value)
         {
-            if (value == null || value is DBNull) throw new ArgumentNullException("value");
-            string s = value as string;
-            if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", "value");
+            if (value == null || value is DBNull) throw new ArgumentNullException(nameof(value));
+            var s = value as string;
+            if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", nameof(value));
             return s[0];
         }
 
@@ -1439,8 +1434,8 @@ namespace Dapper
         public static char? ReadNullableChar(object value)
         {
             if (value == null || value is DBNull) return null;
-            string s = value as string;
-            if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", "value");
+            var s = value as string;
+            if (s == null || s.Length != 1) throw new ArgumentException("A single-character was expected", nameof(value));
             return s[0];
         }
 
@@ -1493,8 +1488,8 @@ namespace Dapper
             {
                 var list = value as IEnumerable;
                 var count = 0;
-                bool isString = value is IEnumerable<string>;
-                bool isDbString = value is IEnumerable<DbString>;
+                var isString = value is IEnumerable<string>;
+                var isDbString = value is IEnumerable<DbString>;
                 DbType dbType = 0;
                 if (list != null)
                 {
@@ -1550,7 +1545,7 @@ namespace Dapper
                         {
                             return "(SELECT " + variableName + " WHERE 1 = 0)";
                         }
-                    }, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);                        
+                    }, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
                     var dummyParam = command.CreateParameter();
                     dummyParam.ParameterName = namePrefix;
                     dummyParam.Value = DBNull.Value;
@@ -1565,9 +1560,9 @@ namespace Dapper
                         {
                             // looks like an optimize hint; expand it
                             var suffix = match.Groups[2].Value;
-                                
+
                             var sb = GetStringBuilder().Append(variableName).Append(1).Append(suffix);
-                            for (int i = 2; i <= count; i++)
+                            for (var i = 2; i <= count; i++)
                             {
                                 sb.Append(',').Append(variableName).Append(i).Append(suffix);
                             }
@@ -1576,7 +1571,7 @@ namespace Dapper
                         else
                         {
                             var sb = GetStringBuilder().Append('(').Append(variableName).Append(1);
-                            for (int i = 2; i <= count; i++)
+                            for (var i = 2; i <= count; i++)
                             {
                                 sb.Append(',').Append(variableName).Append(i);
                             }
@@ -1684,8 +1679,8 @@ namespace Dapper
                         if(multiExec != null)
                         {
                             StringBuilder sb = null;
-                            bool first = true;
-                            foreach (object subval in multiExec)
+                            var first = true;
+                            foreach (var subval in multiExec)
                             {
                                 if(first)
                                 {
@@ -1718,9 +1713,9 @@ namespace Dapper
             var sql = command.CommandText;
             foreach (var token in tokens)
             {
-                object value = parameters[token.Member];
+                var value = parameters[token.Member];
 #pragma warning disable 0618
-                string text = Format(value);
+                var text = Format(value);
 #pragma warning restore 0618
                 sql = sql.Replace(token.Token, text);
             }
@@ -1734,10 +1729,10 @@ namespace Dapper
 
             var matches = literalTokens.Matches(sql);
             var found = new HashSet<string>(StringComparer.Ordinal);
-            List<LiteralToken> list = new List<LiteralToken>(matches.Count);
+            var list = new List<LiteralToken>(matches.Count);
             foreach(Match match in matches)
             {
-                string token = match.Value;
+                var token = match.Value;
                 if(found.Add(match.Value))
                 {
                     list.Add(new LiteralToken(token, match.Groups[1].Value));
@@ -1756,19 +1751,19 @@ namespace Dapper
 
         internal static Action<IDbCommand, object> CreateParamInfoGenerator(Identity identity, bool checkForDuplicates, bool removeUnused, IList<LiteralToken> literals)
         {
-            Type type = identity.parametersType;
-            
-            bool filterParams = false;
+            var type = identity.parametersType;
+
+            var filterParams = false;
             if (removeUnused && identity.commandType.GetValueOrDefault(CommandType.Text) == CommandType.Text)
             {
                 filterParams = !smellsLikeOleDb.IsMatch(identity.sql);
             }
-            var dm = new DynamicMethod(string.Format("ParamInfo{0}", Guid.NewGuid()), null, new[] { typeof(IDbCommand), typeof(object) }, type, true);
+            var dm = new DynamicMethod($"ParamInfo{Guid.NewGuid()}", null, new[] { typeof(IDbCommand), typeof(object) }, type, true);
 
             var il = dm.GetILGenerator();
 
-            bool isStruct = type.IsValueType();
-            bool haveInt32Arg1 = false;
+            var isStruct = type.IsValueType();
+            var haveInt32Arg1 = false;
             il.Emit(OpCodes.Ldarg_1); // stack is now [untyped-param]
             if (isStruct)
             {
@@ -1794,8 +1789,8 @@ namespace Dapper
             if (ctors.Length == 1 && propsArr.Length == (ctorParams = ctors[0].GetParameters()).Length)
             {
                 // check if reflection was kind enough to put everything in the right order for us
-                bool ok = true;
-                for (int i = 0; i < propsArr.Length; i++)
+                var ok = true;
+                for (var i = 0; i < propsArr.Length; i++)
                 {
                     if (!string.Equals(propsArr[i].Name, ctorParams[i].Name, StringComparison.OrdinalIgnoreCase))
                     {
@@ -1816,9 +1811,9 @@ namespace Dapper
                     }
                     if (positionByName.Count == propsArr.Length)
                     {
-                        int[] positions = new int[propsArr.Length];
+                        var positions = new int[propsArr.Length];
                         ok = true;
-                        for (int i = 0; i < propsArr.Length; i++)
+                        for (var i = 0; i < propsArr.Length; i++)
                         {
                             int pos;
                             if (!positionByName.TryGetValue(propsArr[i].Name, out pos))
@@ -1855,7 +1850,7 @@ namespace Dapper
                     continue;
                 }
                 ITypeHandler handler;
-                DbType dbType = LookupDbType(prop.PropertyType, prop.Name, true, out handler);
+                var dbType = LookupDbType(prop.PropertyType, prop.Name, true, out handler);
                 if (dbType == DynamicParameters.EnumerableMultiParameter)
                 {
                     // this actually represents special handling for list types;
@@ -1914,7 +1909,7 @@ namespace Dapper
                 il.Emit(OpCodes.Dup);// stack is now [parameters] [[parameters]] [parameter] [parameter]
                 il.Emit(OpCodes.Ldloc_0); // stack is now [parameters] [[parameters]] [parameter] [parameter] [typed-param]
                 il.Emit(callOpCode, prop.GetGetMethod()); // stack is [parameters] [[parameters]] [parameter] [parameter] [typed-value]
-                bool checkForNull = true;
+                var checkForNull = true;
                 if (prop.PropertyType.IsValueType())
                 {
                     il.Emit(OpCodes.Box, prop.PropertyType); // stack is [parameters] [[parameters]] [parameter] [parameter] [boxed-value]
@@ -1932,8 +1927,8 @@ namespace Dapper
                     }
                     // relative stack: [boxed value]
                     il.Emit(OpCodes.Dup);// relative stack: [boxed value] [boxed value]
-                    Label notNull = il.DefineLabel();
-                    Label? allDone = (dbType == DbType.String || dbType == DbType.AnsiString) ? il.DefineLabel() : (Label?)null;
+                    var notNull = il.DefineLabel();
+                    var allDone = (dbType == DbType.String || dbType == DbType.AnsiString) ? il.DefineLabel() : (Label?)null;
                     il.Emit(OpCodes.Brtrue_S, notNull);
                     // relative stack [boxed value = null]
                     il.Emit(OpCodes.Pop); // relative stack empty
@@ -1958,7 +1953,7 @@ namespace Dapper
                         il.MarkLabel(isLong);
                         EmitInt32(il, -1); // [string] [-1]
                         il.MarkLabel(lenDone);
-                        il.Emit(OpCodes.Stloc_1); // [string] 
+                        il.Emit(OpCodes.Stloc_1); // [string]
                     }
                     if (prop.PropertyType.FullName == LinqBinary)
                     {
@@ -2021,10 +2016,10 @@ namespace Dapper
                 {
                     // find the best member, preferring case-sensitive
                     PropertyInfo exact = null, fallback = null;
-                    string huntName = literal.Member;
-                    for(int i = 0; i < propsArr.Length;i++)
+                    var huntName = literal.Member;
+                    for(var i = 0; i < propsArr.Length;i++)
                     {
-                        string thisName = propsArr[i].Name;
+                        var thisName = propsArr[i].Name;
                         if(string.Equals(thisName, huntName, StringComparison.OrdinalIgnoreCase))
                         {
                             fallback = propsArr[i];
@@ -2042,7 +2037,7 @@ namespace Dapper
                         il.Emit(OpCodes.Ldstr, literal.Token);
                         il.Emit(OpCodes.Ldloc_0); // command, sql, typed parameter
                         il.EmitCall(callOpCode, prop.GetGetMethod(), null); // command, sql, typed value
-                        Type propType = prop.PropertyType;
+                        var propType = prop.PropertyType;
                         var typeCode = TypeExtensions.GetTypeCode(propType);
                         switch (typeCode)
                         {
@@ -2116,32 +2111,32 @@ namespace Dapper
             MethodInfo method;
             return toStrings.TryGetValue(typeCode, out method) ? method : null;
         }
-        static readonly MethodInfo StringReplace = typeof(string).GetPublicInstanceMethod("Replace", new Type[] { typeof(string), typeof(string) }),
+        static readonly MethodInfo StringReplace = typeof(string).GetPublicInstanceMethod("Replace", new[] { typeof(string), typeof(string) }),
             InvariantCulture = typeof(CultureInfo).GetProperty("InvariantCulture", BindingFlags.Public | BindingFlags.Static).GetGetMethod();
 
         private static int ExecuteCommand(IDbConnection cnn, ref CommandDefinition command, Action<IDbCommand, object> paramReader)
         {
             IDbCommand cmd = null;
-            bool wasClosed = cnn.State == ConnectionState.Closed;
+            var wasClosed = cnn.State == ConnectionState.Closed;
             try
             {
                 cmd = command.SetupCommand(cnn, paramReader);
                 if (wasClosed) cnn.Open();
-                int result = cmd.ExecuteNonQuery();
+                var result = cmd.ExecuteNonQuery();
                 command.OnCompleted();
                 return result;
             }
             finally
             {
                 if (wasClosed) cnn.Close();
-                if (cmd != null) cmd.Dispose();
+                cmd?.Dispose();
             }
         }
 
         private static T ExecuteScalarImpl<T>(IDbConnection cnn, ref CommandDefinition command)
         {
             Action<IDbCommand, object> paramReader = null;
-            object param = command.Parameters;
+            var param = command.Parameters;
             if (param != null)
             {
                 var identity = new Identity(command.CommandText, command.CommandType, cnn, null, param.GetType(), null);
@@ -2149,7 +2144,7 @@ namespace Dapper
             }
 
             IDbCommand cmd = null;
-            bool wasClosed = cnn.State == ConnectionState.Closed;
+            var wasClosed = cnn.State == ConnectionState.Closed;
             object result;
             try
             {
@@ -2161,14 +2156,14 @@ namespace Dapper
             finally
             {
                 if (wasClosed) cnn.Close();
-                if (cmd != null) cmd.Dispose();
+                cmd?.Dispose();
             }
             return Parse<T>(result);
         }
 
         private static IDataReader ExecuteReaderImpl(IDbConnection cnn, ref CommandDefinition command, CommandBehavior commandBehavior, out IDbCommand cmd)
         {
-            Action<IDbCommand, object> paramReader = GetParameterReader(cnn, ref command);
+            var paramReader = GetParameterReader(cnn, ref command);
             cmd = null;
             bool wasClosed = cnn.State == ConnectionState.Closed, disposeCommand = true;
             try
@@ -2191,8 +2186,8 @@ namespace Dapper
 
         private static Action<IDbCommand, object> GetParameterReader(IDbConnection cnn, ref CommandDefinition command)
         {
-            object param = command.Parameters;
-            IEnumerable multiExec = GetMultiExec(param);
+            var param = command.Parameters;
+            var multiExec = GetMultiExec(param);
             CacheInfo info = null;
             if (multiExec != null)
             {
@@ -2215,11 +2210,11 @@ namespace Dapper
 #pragma warning disable 618
             if (type == typeof(char))
             { // this *does* need special handling, though
-                return r => SqlMapper.ReadChar(r.GetValue(index));
+                return r => ReadChar(r.GetValue(index));
             }
             if (type == typeof(char?))
             {
-                return r => SqlMapper.ReadNullableChar(r.GetValue(index));
+                return r => ReadNullableChar(r.GetValue(index));
             }
             if (type.FullName == LinqBinary)
             {
@@ -2278,7 +2273,7 @@ namespace Dapper
         }
 
         static readonly MethodInfo
-                    enumParse = typeof(Enum).GetMethod("Parse", new Type[] { typeof(Type), typeof(string), typeof(bool) }),
+                    enumParse = typeof(Enum).GetMethod("Parse", new[] { typeof(Type), typeof(string), typeof(bool) }),
                     getItem = typeof(IDataRecord).GetProperties(BindingFlags.Instance | BindingFlags.Public)
                         .Where(p => p.GetIndexParameters().Any() && p.GetIndexParameters()[0].ParameterType == typeof(int))
                         .Select(p => p.GetGetMethod()).First();
@@ -2287,7 +2282,7 @@ namespace Dapper
         /// Gets type-map for the given type
         /// </summary>
         /// <returns>Type map instance, default is to create new instance of DefaultTypeMap</returns>
-        public static Func<Type, ITypeMap> TypeMapProvider = ( Type type ) => new DefaultTypeMap( type );
+        public static Func<Type, ITypeMap> TypeMapProvider = type => new DefaultTypeMap( type );
 
         /// <summary>
         /// Gets type-map for the given type
@@ -2295,7 +2290,8 @@ namespace Dapper
         /// <returns>Type map implementation, DefaultTypeMap instance if no override present</returns>
         public static ITypeMap GetTypeMap(Type type)
         {
-            if (type == null) throw new ArgumentNullException("type");
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
 #if DNXCORE50
             ITypeMap map = null;
 #else
@@ -2304,7 +2300,8 @@ namespace Dapper
             if (map == null)
             {
                 lock (_typeMaps)
-                {   // double-checked; store this to avoid reflection next time we see this type
+                {
+                    // double-checked; store this to avoid reflection next time we see this type
                     // since multiple queries commonly use the same domain-entity/DTO/view-model type
 #if DNXCORE50
                     if (!_typeMaps.TryGetValue(type, out map)) map = null;
@@ -2312,9 +2309,9 @@ namespace Dapper
                     map = (ITypeMap)_typeMaps[type];
 #endif
 
-                        if (map == null)
+                    if (map == null)
                     {
-                        map = TypeMapProvider( type );
+                        map = TypeMapProvider(type);
                         _typeMaps[type] = map;
                     }
                 }
@@ -2337,7 +2334,7 @@ namespace Dapper
         public static void SetTypeMap(Type type, ITypeMap map)
         {
             if (type == null)
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
 
             if (map == null || map is DefaultTypeMap)
             {
@@ -2371,7 +2368,7 @@ namespace Dapper
         )
         {
 
-            var dm = new DynamicMethod(string.Format("Deserialize{0}", Guid.NewGuid()), typeof(object), new[] { typeof(IDataReader) }, true);
+            var dm = new DynamicMethod($"Deserialize{Guid.NewGuid()}", typeof(object), new[] { typeof(IDataReader) }, true);
             var il = dm.GetILGenerator();
             il.DeclareLocal(typeof(int));
             il.DeclareLocal(type);
@@ -2390,14 +2387,14 @@ namespace Dapper
 
             var names = Enumerable.Range(startBound, length).Select(i => reader.GetName(i)).ToArray();
 
-            ITypeMap typeMap = GetTypeMap(type);
+            var typeMap = GetTypeMap(type);
 
-            int index = startBound;
+            var index = startBound;
 
             ConstructorInfo specializedConstructor = null;
 
 #if !DNXCORE50
-            bool supportInitialize = false;
+            var supportInitialize = false;
 #endif
             if (type.IsValueType())
             {
@@ -2407,7 +2404,7 @@ namespace Dapper
             else
             {
                 var types = new Type[length];
-                for (int i = startBound; i < startBound + length; i++)
+                for (var i = startBound; i < startBound + length; i++)
                 {
                     types[i - startBound] = reader.GetFieldType(i);
                 }
@@ -2455,8 +2452,8 @@ namespace Dapper
                     var ctor = typeMap.FindConstructor(names, types);
                     if (ctor == null)
                     {
-                        string proposedTypes = "(" + string.Join(", ", types.Select((t, i) => t.FullName + " " + names[i]).ToArray()) + ")";
-                        throw new InvalidOperationException(string.Format("A parameterless default constructor or one matching signature {0} is required for {1} materialization", proposedTypes, type.FullName));
+                        var proposedTypes = "(" + string.Join(", ", types.Select((t, i) => t.FullName + " " + names[i]).ToArray()) + ")";
+                        throw new InvalidOperationException($"A parameterless default constructor or one matching signature {proposedTypes} is required for {type.FullName} materialization");
                     }
 
                     if (ctor.GetParameters().Length == 0)
@@ -2495,7 +2492,7 @@ namespace Dapper
 
             // stack is now [target]
 
-            bool first = true;
+            var first = true;
             var allDone = il.DefineLabel();
             int enumDeclareLocal = -1, valueCopyLocal = il.DeclareLocal(typeof(object)).LocalIndex;
             foreach (var item in members)
@@ -2504,8 +2501,8 @@ namespace Dapper
                 {
                     if (specializedConstructor == null)
                         il.Emit(OpCodes.Dup); // stack is now [target][target]
-                    Label isDbNullLabel = il.DefineLabel();
-                    Label finishLabel = il.DefineLabel();
+                    var isDbNullLabel = il.DefineLabel();
+                    var finishLabel = il.DefineLabel();
 
                     il.Emit(OpCodes.Ldarg_0); // stack is now [target][target][reader]
                     EmitInt32(il, index); // stack is now [target][target][reader][index]
@@ -2514,8 +2511,8 @@ namespace Dapper
                     il.Emit(OpCodes.Callvirt, getItem); // stack is now [target][target][value-as-object]
                     il.Emit(OpCodes.Dup); // stack is now [target][target][value-as-object][value-as-object]
                     StoreLocal(il, valueCopyLocal);
-                    Type colType = reader.GetFieldType(index);
-                    Type memberType = item.MemberType;
+                    var colType = reader.GetFieldType(index);
+                    var memberType = item.MemberType;
 
                     if (memberType == typeof(char) || memberType == typeof(char?))
                     {
@@ -2535,7 +2532,7 @@ namespace Dapper
 
                         if (unboxType.IsEnum())
                         {
-                            Type numericType = Enum.GetUnderlyingType(unboxType);
+                            var numericType = Enum.GetUnderlyingType(unboxType);
                             if(colType == typeof(string))
                             {
                                 if (enumDeclareLocal == -1)
@@ -2564,7 +2561,7 @@ namespace Dapper
                         else if (memberType.FullName == LinqBinary)
                         {
                             il.Emit(OpCodes.Unbox_Any, typeof(byte[])); // stack is now [target][target][byte-array]
-                            il.Emit(OpCodes.Newobj, memberType.GetConstructor(new Type[] { typeof(byte[]) }));// stack is now [target][target][binary]
+                            il.Emit(OpCodes.Newobj, memberType.GetConstructor(new[] { typeof(byte[]) }));// stack is now [target][target][binary]
                         }
                         else
                         {
@@ -2617,7 +2614,7 @@ namespace Dapper
                         il.Emit(OpCodes.Pop);
                         if (item.MemberType.IsValueType())
                         {
-                            int localIndex = il.DeclareLocal(item.MemberType).LocalIndex;
+                            var localIndex = il.DeclareLocal(item.MemberType).LocalIndex;
                             LoadLocalAddress(il, localIndex);
                             il.Emit(OpCodes.Initobj, item.MemberType);
                             LoadLocal(il, localIndex);
@@ -2698,8 +2695,8 @@ namespace Dapper
             }
             else
             {
-                bool handled = false;
-                OpCode opCode = default(OpCode);
+                var handled = false;
+                var opCode = default(OpCode);
                 switch (TypeExtensions.GetTypeCode(from))
                 {
                     case TypeCode.Boolean:
@@ -2759,10 +2756,10 @@ namespace Dapper
                 {
                     il.Emit(OpCodes.Ldtoken, via ?? to); // stack is now [target][target][value][member-type-token]
                     il.EmitCall(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle"), null); // stack is now [target][target][value][member-type]
-                    il.EmitCall(OpCodes.Call, typeof(Convert).GetMethod("ChangeType", new Type[] { typeof(object), typeof(Type) }), null); // stack is now [target][target][boxed-member-type-value]
+                    il.EmitCall(OpCodes.Call, typeof(Convert).GetMethod("ChangeType", new[] { typeof(object), typeof(Type) }), null); // stack is now [target][target][boxed-member-type-value]
                     il.Emit(OpCodes.Unbox_Any, to); // stack is now [target][target][typed-value]
                 }
-            }            
+            }
         }
 
         static MethodInfo GetOperator(Type from, Type to)
@@ -2777,7 +2774,7 @@ namespace Dapper
         }
         static MethodInfo ResolveOperator(MethodInfo[] methods, Type from, Type to, string name)
         {
-            for (int i = 0; i < methods.Length; i++)
+            for (var i = 0; i < methods.Length; i++)
             {
                 if (methods[i].Name != name || methods[i].ReturnType != to) continue;
                 var args = methods[i].GetParameters();
@@ -2789,7 +2786,7 @@ namespace Dapper
 
         private static void LoadLocal(ILGenerator il, int index)
         {
-            if (index < 0 || index >= short.MaxValue) throw new ArgumentNullException("index");
+            if (index < 0 || index >= short.MaxValue) throw new ArgumentNullException(nameof(index));
             switch (index)
             {
                 case 0: il.Emit(OpCodes.Ldloc_0); break;
@@ -2810,7 +2807,7 @@ namespace Dapper
         }
         private static void StoreLocal(ILGenerator il, int index)
         {
-            if (index < 0 || index >= short.MaxValue) throw new ArgumentNullException("index");
+            if (index < 0 || index >= short.MaxValue) throw new ArgumentNullException(nameof(index));
             switch (index)
             {
                 case 0: il.Emit(OpCodes.Stloc_0); break;
@@ -2831,7 +2828,7 @@ namespace Dapper
         }
         private static void LoadLocalAddress(ILGenerator il, int index)
         {
-            if (index < 0 || index >= short.MaxValue) throw new ArgumentNullException("index");
+            if (index < 0 || index >= short.MaxValue) throw new ArgumentNullException(nameof(index));
 
             if (index <= 255)
             {
@@ -2871,7 +2868,7 @@ namespace Dapper
                         formattedValue = valEx.Message;
                     }
                 }
-                toThrow = new DataException(string.Format("Error parsing column {0} ({1}={2})", index, name, formattedValue), ex);
+                toThrow = new DataException($"Error parsing column {index} ({name}={formattedValue})", ex);
             }
             catch
             { // throw the **original** exception, wrapped as DataException
@@ -2956,7 +2953,7 @@ namespace Dapper
         /// </summary>
         public static string GetTypeName(this DataTable table)
         {
-            return table == null ? null : table.ExtendedProperties[DataTableTypeNameKey] as string;
+            return table?.ExtendedProperties[DataTableTypeNameKey] as string;
         }
 
         /// <summary>

--- a/Dapper/TypeExtensions.cs
+++ b/Dapper/TypeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Collections.Generic;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -13,6 +14,7 @@ using IDataParameterCollection = global::System.Data.Common.DbParameterCollectio
 using DataException = global::System.InvalidOperationException;
 using ApplicationException = global::System.InvalidOperationException;
 #endif
+
 namespace Dapper
 {
     internal static class TypeExtensions
@@ -25,6 +27,7 @@ namespace Dapper
             return type.IsValueType;
 #endif
         }
+
         public static bool IsEnum(this Type type)
         {
 #if DNXCORE50
@@ -33,6 +36,7 @@ namespace Dapper
             return type.IsEnum;
 #endif
         }
+
 #if DNXCORE50
         public static TypeCode GetTypeCode(Type type)
         {
@@ -72,6 +76,7 @@ namespace Dapper
             return Type.GetTypeCode(type);
         }
 #endif
+
         public static MethodInfo GetPublicInstanceMethod(this Type type, string name, Type[] types)
         {
 #if DNXCORE50
@@ -81,7 +86,5 @@ namespace Dapper
             return type.GetMethod(name, BindingFlags.Instance | BindingFlags.Public, null, types, null);
 #endif
         }
-
-
     }
 }

--- a/Dapper/UdtTypeHandler.cs
+++ b/Dapper/UdtTypeHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.SqlClient;
 
 namespace Dapper
 {
@@ -13,14 +14,19 @@ namespace Dapper
         public class UdtTypeHandler : ITypeHandler
         {
             private readonly string udtTypeName;
+
             /// <summary>
             /// Creates a new instance of UdtTypeHandler with the specified UdtTypeName
             /// </summary>
             public UdtTypeHandler(string udtTypeName)
             {
-                if (string.IsNullOrEmpty(udtTypeName)) throw new ArgumentException("Cannot be null or empty", udtTypeName);
+                if (string.IsNullOrEmpty(udtTypeName))
+                {
+                    throw new ArgumentException("Cannot be null or empty", udtTypeName);
+                }
                 this.udtTypeName = udtTypeName;
             }
+
             object ITypeHandler.Parse(Type destinationType, object value)
             {
                 return value is DBNull ? null : value;
@@ -29,10 +35,10 @@ namespace Dapper
             void ITypeHandler.SetValue(IDbDataParameter parameter, object value)
             {
                 parameter.Value = SanitizeParameterValue(value);
-                if (parameter is System.Data.SqlClient.SqlParameter && !(value is DBNull))
+                if (parameter is SqlParameter && !(value is DBNull))
                 {
-                    ((System.Data.SqlClient.SqlParameter)parameter).SqlDbType = SqlDbType.Udt;
-                    ((System.Data.SqlClient.SqlParameter)parameter).UdtTypeName = udtTypeName;
+                    ((SqlParameter)parameter).SqlDbType = SqlDbType.Udt;
+                    ((SqlParameter)parameter).UdtTypeName = udtTypeName;
                 }
             }
         }

--- a/Dapper/WrappedDataReader.cs
+++ b/Dapper/WrappedDataReader.cs
@@ -26,6 +26,7 @@ namespace Dapper
         /// Obtain the underlying reader
         /// </summary>
         public abstract IDataReader Reader { get; }
+
         /// <summary>
         /// Obtain the underlying command
         /// </summary>
@@ -42,6 +43,7 @@ namespace Dapper
         /// Obtain the underlying reader
         /// </summary>
         IDataReader Reader { get; }
+
         /// <summary>
         /// Obtain the underlying command
         /// </summary>

--- a/Dapper/WrappedReader.cs
+++ b/Dapper/WrappedReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Collections;
+
 #if DNXCORE50
 using IDbDataParameter = global::System.Data.Common.DbParameter;
 using IDataParameter = global::System.Data.Common.DbParameter;
@@ -50,22 +51,12 @@ namespace Dapper
             }
         }
 
-        public override int Depth
-        {
-            get { return Reader.Depth; }
-        }
+        public override int Depth => Reader.Depth;
 
-        public override bool IsClosed
-        {
-            get { return reader == null ? true : reader.IsClosed; }
-        }
-        public override bool HasRows
-        {
-            get
-            {
-                return Reader.HasRows;
-            }
-        }
+        public override bool IsClosed => reader?.IsClosed ?? true;
+
+        public override bool HasRows => Reader.HasRows;
+
         public override bool NextResult()
         {
             return Reader.NextResult();
@@ -76,28 +67,22 @@ namespace Dapper
             return Reader.Read();
         }
 
-        public override int RecordsAffected
-        {
-            get { return Reader.RecordsAffected; }
-        }
+        public override int RecordsAffected => Reader.RecordsAffected;
 
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (reader != null) reader.Dispose();
+                reader?.Dispose();
                 reader = null;
-                if (cmd != null) cmd.Dispose();
+                cmd?.Dispose();
                 cmd = null;
             }
             base.Dispose(disposing);
         }
 
-        public override int FieldCount
-        {
-            get { return Reader.FieldCount; }
-        }
+        public override int FieldCount => Reader.FieldCount;
 
         public override bool GetBoolean(int i)
         {
@@ -209,19 +194,12 @@ namespace Dapper
             return Reader.IsDBNull(i);
         }
 
-        public override object this[string name]
-        {
-            get { return Reader[name]; }
-        }
+        public override object this[string name] => Reader[name];
 
-        public override object this[int i]
-        {
-            get { return Reader[i]; }
-        }
+        public override object this[int i] => Reader[i];
     }
 #else
-
-    internal class WrappedReader : IDataReader, IWrappedDataReader
+    internal class WrappedReader : IWrappedDataReader
     {
         private IDataReader reader;
         private IDbCommand cmd;
@@ -231,19 +209,27 @@ namespace Dapper
             get
             {
                 var tmp = reader;
-                if (tmp == null) throw new ObjectDisposedException(GetType().Name);
+                if (tmp == null)
+                {
+                    throw new ObjectDisposedException(GetType().Name);
+                }
                 return tmp;
             }
         }
+
         IDbCommand IWrappedDataReader.Command
         {
             get
             {
                 var tmp = cmd;
-                if (tmp == null) throw new ObjectDisposedException(GetType().Name);
+                if (tmp == null)
+                {
+                    throw new ObjectDisposedException(GetType().Name);
+                }
                 return tmp;
             }
         }
+
         public WrappedReader(IDbCommand cmd, IDataReader reader)
         {
             this.cmd = cmd;
@@ -252,23 +238,17 @@ namespace Dapper
 
         void IDataReader.Close()
         {
-            if (reader != null) reader.Close();
+            reader?.Close();
         }
 
-        int IDataReader.Depth
-        {
-            get { return Reader.Depth; }
-        }
+        int IDataReader.Depth => Reader.Depth;
 
         DataTable IDataReader.GetSchemaTable()
         {
             return Reader.GetSchemaTable();
         }
 
-        bool IDataReader.IsClosed
-        {
-            get { return reader == null ? true : reader.IsClosed; }
-        }
+        bool IDataReader.IsClosed => reader?.IsClosed ?? true;
 
         bool IDataReader.NextResult()
         {
@@ -280,24 +260,18 @@ namespace Dapper
             return Reader.Read();
         }
 
-        int IDataReader.RecordsAffected
-        {
-            get { return Reader.RecordsAffected; }
-        }
+        int IDataReader.RecordsAffected => Reader.RecordsAffected;
 
         void IDisposable.Dispose()
         {
-            if (reader != null) reader.Close();
-            if (reader != null) reader.Dispose();
+            reader?.Close();
+            reader?.Dispose();
             reader = null;
-            if (cmd != null) cmd.Dispose();
+            cmd?.Dispose();
             cmd = null;
         }
 
-        int IDataRecord.FieldCount
-        {
-            get { return Reader.FieldCount; }
-        }
+        int IDataRecord.FieldCount => Reader.FieldCount;
 
         bool IDataRecord.GetBoolean(int i)
         {
@@ -409,15 +383,9 @@ namespace Dapper
             return Reader.IsDBNull(i);
         }
 
-        object IDataRecord.this[string name]
-        {
-            get { return Reader[name]; }
-        }
+        object IDataRecord.this[string name] => Reader[name];
 
-        object IDataRecord.this[int i]
-        {
-            get { return Reader[i]; }
-        }
+        object IDataRecord.this[int i] => Reader[i];
     }
 #endif
 }


### PR DESCRIPTION
- Overall formatting (except the big `SqlMapper(Async)`)
- Use `var` where possible
- Use string interpolation
- Use expression bodies
- Use auto, read-only properties
- Use null progagation
- Use `nameof` operator
- Arrange `this.` and namespace qualifiers
- Use dictionary initializers