### PR TITLE
Add `System.Xml` framework assembly

### DIFF
--- a/Dapper/project.json
+++ b/Dapper/project.json
@@ -17,13 +17,15 @@
         "warningsAsErrors": true
       },
       "frameworkAssemblies": {
-        "System.Data": "4.0.0.0"
+        "System.Data": "4.0.0.0",
+        "System.Xml": "4.0.0.0"
       }
     },
     "net40": {
       "compilationOptions": { "warningsAsErrors": true },
       "frameworkAssemblies": {
-        "System.Data": "4.0.0.0"
+        "System.Data": "4.0.0.0",
+        "System.Xml": "4.0.0.0"
       }
     },
     "dnx451": {
@@ -32,7 +34,8 @@
         "warningsAsErrors": true
       },
       "frameworkAssemblies": {
-        "System.Data": "4.0.0.0"
+        "System.Data": "4.0.0.0",
+        "System.Xml": "4.0.0.0"
       }
     },
     "dnxcore50": {


### PR DESCRIPTION
Without it, Resharper complains about needing the `System.Xml` module when using the `DataTable` class. Project compiles fine without it though. The .NET 4.0 .csproj file included it as well.