### PR TITLE
Make DefaultTypeMap public again

### DIFF
--- a/Dapper/DefaultTypeMap.cs
+++ b/Dapper/DefaultTypeMap.cs
@@ -8,7 +8,7 @@ namespace Dapper
     /// <summary>
     /// Represents default type mapping strategy used by Dapper
     /// </summary>
-    sealed class DefaultTypeMap : SqlMapper.ITypeMap
+    public sealed class DefaultTypeMap : SqlMapper.ITypeMap
     {
         private readonly List<FieldInfo> _fields;
         private readonly Type _type;


### PR DESCRIPTION
It used to be public before. I use it to provide a fallback typemap when there is no mapping configured using [Dapper.FluentMap](https://github.com/henkmollema/Dapper-FluentMap).

Is there a particular reason it's not public anymore?