### PR TITLE
MySQL Test Suite for Contrib

### DIFF
--- a/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -5,7 +5,11 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Dapper.Contrib.Extensions;
+#if XUNIT2
+using FactAttribute = Dapper.Tests.Contrib.SkippableFactAttribute;
+#else
 using Xunit;
+#endif
 
 namespace Dapper.Tests.Contrib
 {

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -13,6 +13,9 @@ using IDbConnection = System.Data.Common.DbConnection;
 using System.Data.SqlServerCe;
 using System.Transactions;
 #endif
+#if XUNIT2
+using FactAttribute = Dapper.Tests.Contrib.SkippableFactAttribute;
+#endif
 
 namespace Dapper.Tests.Contrib
 {

--- a/Dapper.Tests.Contrib/project.json
+++ b/Dapper.Tests.Contrib/project.json
@@ -5,7 +5,7 @@
   "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
   "description": "Dapper Contrib Test Suite",
   "title": "Dapper.Contrib.Tests",
-  "version": "1.0.0-*",
+  "version": "1.0.0",
   "copyright": "2015 Stack Exchange, Inc.",
   "dependencies": {
     "Dapper": {
@@ -24,6 +24,7 @@
   "compile": [
     "**/*.cs",
     "../Dapper.Tests/Assert.cs",
+    "../Dapper.Tests/XunitSkippable.cs",
     "../Dapper/TypeExtensions.cs"
   ],
   "commands": {
@@ -50,7 +51,7 @@
     },
     "net45": {
       "compilationOptions": {
-        "define": [ "ASYNC" ]
+        "define": [ "ASYNC", "XUNIT2" ]
       },
       "frameworkAssemblies": {
         "System.Configuration": "4.0.0.0",
@@ -69,7 +70,7 @@
     },
     "dotnet5.4": {
       "compilationOptions": {
-        "define": [ "ASYNC", "COREFX" ]
+        "define": [ "ASYNC", "COREFX", "XUNIT2" ]
       },
       "dependencies": {
         "Microsoft.CSharp": "4.0.1-*",
@@ -85,7 +86,7 @@
     },
     "dnx451": {
       "compilationOptions": {
-        "define": [ "ASYNC" ]
+        "define": [ "ASYNC", "XUNIT2" ]
       },
       "frameworkAssemblies": {
         "System.Configuration": "4.0.0.0",
@@ -102,7 +103,7 @@
     },
     "dnxcore50": {
       "compilationOptions": {
-        "define": [ "COREFX", "ASYNC" ]
+        "define": [ "COREFX", "ASYNC", "XUNIT2" ]
       },
       "dependencies": {
         "Microsoft.Data.Sqlite": "1.0.0-rc1-final",

--- a/Dapper.Tests.Contrib/project.json
+++ b/Dapper.Tests.Contrib/project.json
@@ -43,6 +43,7 @@
       },
       "dependencies": {
         "Microsoft.SqlServer.Compact": "4.0.8876.1",
+        "MySql.Data": "6.9.8",
         "System.Data.SQLite.Core": "1.0.98.1",
         "xunit": "1.9.2"
       }
@@ -61,6 +62,7 @@
       },
       "dependencies": {
         "Microsoft.SqlServer.Compact": "4.0.8876.1",
+        "MySql.Data": "6.9.8",
         "System.Data.SQLite.Core": "1.0.98.1",
         "xunit": "2.1.0"
       }
@@ -92,6 +94,7 @@
       },
       "dependencies": {
         "Microsoft.SqlServer.Compact": "4.0.8876.1",
+        "MySql.Data": "6.9.8",
         "System.Data.SQLite.Core": "1.0.98.1",
         "xunit": "2.1.0",
         "xunit.runner.dnx": "2.1.0-*"

--- a/Dapper.Tests/Tests.cs
+++ b/Dapper.Tests/Tests.cs
@@ -698,10 +698,10 @@ select * from @bar", new { foo }).Single();
         [Fact]
         public void MultiRSSqlCE()
         {
-            if (File.Exists("Test.sdf"))
-                File.Delete("Test.sdf");
+            if (File.Exists("Test.DB.sdf"))
+                File.Delete("Test.DB.sdf");
 
-            var cnnStr = "Data Source = Test.sdf;";
+            var cnnStr = "Data Source = Test.DB.sdf;";
             var engine = new SqlCeEngine(cnnStr);
             engine.CreateDatabase();
 

--- a/Dapper.Tests/Tests.cs
+++ b/Dapper.Tests/Tests.cs
@@ -68,14 +68,15 @@ namespace Dapper.Tests
 {
     public partial class TestSuite : IDisposable
     {
-        public const string LocalConnectionString = "Data Source=.;Initial Catalog=tempdb;Integrated Security=True",
-            AppveyorConnectionStrng = @"Server=(local)\SQL2014;Database=tempdb;User ID=sa;Password=Password12!",
-            OleDbConnectionString = "Provider=SQLOLEDB;Data Source=.;Initial Catalog=tempdb;Integrated Security=SSPI";
-
         public static string ConnectionString =>
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPVEYOR"))
-                ? AppveyorConnectionStrng
-                : LocalConnectionString;
+                ? @"Server=(local)\SQL2014;Database=tempdb;User ID=sa;Password=Password12!"
+                : "Data Source=.;Initial Catalog=tempdb;Integrated Security=True";
+
+        public static string OleDbConnectionString =>
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPVEYOR"))
+                ? @"Provider=SQLOLEDB;Data Source=(local)\SQL2014;Initial Catalog=tempdb;User Id=sa;Password=Password12!"
+                : "Provider=SQLOLEDB;Data Source=.;Initial Catalog=tempdb;Integrated Security=SSPI";
 
         public static SqlConnection GetOpenConnection(bool mars = false)
         {

--- a/Dapper.Tests/XunitSkippable.cs
+++ b/Dapper.Tests/XunitSkippable.cs
@@ -1,0 +1,98 @@
+﻿using System;
+
+#if XUNIT2 // Not in .Net 4.0 (xUnit v1)...
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+#endif
+
+namespace Dapper.Tests
+{
+    public class SkipTestException : Exception
+    {
+        public SkipTestException(string reason) : base(reason) { }
+    }
+
+#if XUNIT2
+    // Most of the below is a direct copy & port from the wonderful examples by Brad Wilson at
+    // https://github.com/xunit/samples.xunit/tree/master/DynamicSkipExample
+    public class SkippableFactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        readonly IMessageSink _diagnosticMessageSink;
+
+        public SkippableFactDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            yield return new SkippableFactTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+        }
+    }
+    
+    public class SkippableFactTestCase : XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkippableFactTestCase() { }
+
+        public SkippableFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        { }
+
+        public override async Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            var skipMessageBus = new SkippableFactMessageBus(messageBus);
+            var result = await base.RunAsync(
+                diagnosticMessageSink,
+                skipMessageBus,
+                constructorArguments,
+                aggregator,
+                cancellationTokenSource);
+            if (skipMessageBus.DynamicallySkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.DynamicallySkippedTestCount;
+                result.Skipped += skipMessageBus.DynamicallySkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+
+    public class SkippableFactMessageBus : IMessageBus
+    {
+        readonly IMessageBus _innerBus;
+        public SkippableFactMessageBus(IMessageBus innerBus)
+        {
+            _innerBus = innerBus;
+        }
+
+        public int DynamicallySkippedTestCount { get; private set; }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            var testFailed = message as ITestFailed;
+            if (testFailed != null)
+            {
+                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+                if (exceptionType == typeof(SkipTestException).FullName)
+                {
+                    DynamicallySkippedTestCount++;
+                    return _innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
+                }
+            }
+            return _innerBus.QueueMessage(message);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
This runs the MySQL tests *if the server is running*, and otherwise throws them in the skip category. It also allows us to do similar for the next `n` test suites for any project (that's why I put the core code up in `Dapper.Tests` for both to use).

In theory, Appveyor will be running these when I hit this PR create button.