### PR TITLE
Fix for #281 - Change CommandBehavior on ExecuteReaderAsync to match sync version

### DIFF
--- a/Dapper.Tests/Tests.Async.cs
+++ b/Dapper.Tests/Tests.Async.cs
@@ -734,6 +734,19 @@ SET @AddressPersonId = @PersonId", p))
                 ", new Product { Id = 1 })).Single();
             id.IsEqualTo(2);
         }
+
+        [Fact]
+        public async Task Issue1281_DataReaderOutOfOrderAsync()
+        {
+            using (var reader = await connection.ExecuteReaderAsync("Select 0, 1, 2"))
+            {
+                reader.Read().IsTrue();
+                reader.GetInt32(2).IsEqualTo(2);
+                reader.GetInt32(0).IsEqualTo(0);
+                reader.GetInt32(1).IsEqualTo(1);
+                reader.Read().IsFalse();
+            }
+        }
     }
 }
 #endif

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -721,7 +721,7 @@ namespace Dapper
             {
                 cmd = (DbCommand)command.SetupCommand(cnn, paramReader);
                 if (wasClosed) await ((DbConnection)cnn).OpenAsync(command.CancellationToken).ConfigureAwait(false);
-                var reader = await cmd.ExecuteReaderAsync(GetBehavior(wasClosed, CommandBehavior.SequentialAccess), command.CancellationToken).ConfigureAwait(false);
+                var reader = await cmd.ExecuteReaderAsync(GetBehavior(wasClosed, CommandBehavior.Default), command.CancellationToken).ConfigureAwait(false);
                 wasClosed = false;
                 return reader;
             }


### PR DESCRIPTION
Issue #281 stems from differences between `ExecuteReader` and `ExecuteReaderAsync`. Though the overloads differ the basics are:

`ExecuteReaderAsync` -> `ExecuteReaderImplAsync` uses `CommandBehavior.SequentialAccess`
`ExecuteReader` -> `ExecuteReaderImpl` uses `CommandBehavior.Default`

There's also an overload in the middle where ExecuteReader allows specifying command behavior which doesn't exist on async...but I wouldn't add that until someone asks for it.

Doing this as a PR because I'm unaware of any reason this would be `SequentialAccess` and differ - I *assume* it's a historical artifact from a copy of `Query` code forever ago...but there may be a reason, so this gets some extra eyes.