### PR TITLE
Custom type handlers for enums are ignored

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -360,6 +360,10 @@ namespace Dapper
             handler = null;
             var nullUnderlyingType = Nullable.GetUnderlyingType(type);
             if (nullUnderlyingType != null) type = nullUnderlyingType;
+            if (typeHandlers.TryGetValue(type, out handler))
+            {
+                return DbType.Object;
+            }
             if (type.IsEnum() && !typeMap.ContainsKey(type))
             {
                 type = Enum.GetUnderlyingType(type);
@@ -371,10 +375,6 @@ namespace Dapper
             if (type.FullName == LinqBinary)
             {
                 return DbType.Binary;
-            }
-            if (typeHandlers.TryGetValue(type, out handler))
-            {
-                return DbType.Object;
             }
             if (typeof(IEnumerable).IsAssignableFrom(type))
             {
@@ -1613,15 +1613,15 @@ namespace Dapper
             {
                 return GetDapperRowDeserializer(reader, startBound, length, returnNullIfFirstMissing);
             }
+            ITypeHandler handler;
+            if (typeHandlers.TryGetValue(type, out handler))
+            {
+                return GetHandlerDeserializer(handler, type, startBound);
+            }
             Type underlyingType = null;
             if (!(typeMap.ContainsKey(type) || type.IsEnum() || type.FullName == LinqBinary ||
                 (type.IsValueType()  && (underlyingType = Nullable.GetUnderlyingType(type)) != null && underlyingType.IsEnum())))
             {
-                ITypeHandler handler;
-                if (typeHandlers.TryGetValue(type, out handler))
-                {
-                    return GetHandlerDeserializer(handler, type, startBound);
-                }
                 return GetTypeDeserializer(type, reader, startBound, length, returnNullIfFirstMissing);
             }
             return GetStructDeserializer(type, underlyingType ?? type, startBound);
@@ -2508,6 +2508,15 @@ namespace Dapper
         private static Func<IDataReader, object> GetStructDeserializer(Type type, Type effectiveType, int index)
         {
             // no point using special per-type handling here; it boils down to the same, plus not all are supported anyway (see: SqlDataReader.GetChar - not supported!)
+            ITypeHandler handler;
+            if (typeHandlers.TryGetValue(type, out handler))
+            {
+                return r =>
+                {
+                    var val = r.GetValue(index);
+                    return val is DBNull ? null : handler.Parse(type, val);
+                };
+            }
 #pragma warning disable 618
             if (type == typeof(char))
             { // this *does* need special handling, though
@@ -2535,15 +2544,6 @@ namespace Dapper
                     return val is DBNull ? null : Enum.ToObject(effectiveType, val);
                 };
             }
-            ITypeHandler handler;
-            if(typeHandlers.TryGetValue(type, out handler))
-            {
-                return r =>
-                {
-                    var val = r.GetValue(index);
-                    return val is DBNull ? null : handler.Parse(type, val);
-                };
-            }
             return r =>
             {
                 var val = r.GetValue(index);
@@ -2557,6 +2557,11 @@ namespace Dapper
             if (value is T) return (T)value;
             var type = typeof(T);
             type = Nullable.GetUnderlyingType(type) ?? type;
+            ITypeHandler handler;
+            if (typeHandlers.TryGetValue(type, out handler))
+            {
+                return (T)handler.Parse(type, value);
+            }
             if (type.IsEnum())
             {
                 if (value is float || value is double || value is decimal)
@@ -2564,11 +2569,6 @@ namespace Dapper
                     value = Convert.ChangeType(value, Enum.GetUnderlyingType(type), CultureInfo.InvariantCulture);
                 }
                 return (T)Enum.ToObject(type, value);
-            }
-            ITypeHandler handler;
-            if (typeHandlers.TryGetValue(type, out handler))
-            {
-                return (T)handler.Parse(type, value);
             }
             return (T)Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
         }
@@ -2817,7 +2817,22 @@ namespace Dapper
                     Type colType = reader.GetFieldType(index);
                     Type memberType = item.MemberType;
 
-                    if (memberType == typeof(char) || memberType == typeof(char?))
+                    // unbox nullable enums as the primitive, i.e. byte etc
+                    var nullUnderlyingType = Nullable.GetUnderlyingType(memberType);
+                    var unboxType = nullUnderlyingType != null && nullUnderlyingType.IsEnum() ? nullUnderlyingType : memberType;
+
+                    bool hasTypeHandler = typeHandlers.ContainsKey(unboxType);
+
+                    if (hasTypeHandler)
+                    {
+                        il.Emit(OpCodes.Dup); // stack is now [target][target][value][value]
+                        il.Emit(OpCodes.Isinst, typeof(DBNull)); // stack is now [target][target][value-as-object][DBNull or null]
+                        il.Emit(OpCodes.Brtrue_S, isDbNullLabel); // stack is now [target][target][value-as-object]
+#pragma warning disable 618
+                        il.EmitCall(OpCodes.Call, typeof(TypeHandlerCache<>).MakeGenericType(unboxType).GetMethod(nameof(TypeHandlerCache<int>.Parse)), null); // stack is now [target][target][typed-value]
+#pragma warning restore 618
+                    }
+                    else if (memberType == typeof(char) || memberType == typeof(char?))
                     {
                         il.EmitCall(OpCodes.Call, typeof(SqlMapper).GetMethod(
                             memberType == typeof(char) ? nameof(SqlMapper.ReadChar) : nameof(SqlMapper.ReadNullableChar), BindingFlags.Static | BindingFlags.Public), null); // stack is now [target][target][typed-value]
@@ -2827,11 +2842,6 @@ namespace Dapper
                         il.Emit(OpCodes.Dup); // stack is now [target][target][value][value]
                         il.Emit(OpCodes.Isinst, typeof(DBNull)); // stack is now [target][target][value-as-object][DBNull or null]
                         il.Emit(OpCodes.Brtrue_S, isDbNullLabel); // stack is now [target][target][value-as-object]
-
-                        // unbox nullable enums as the primitive, i.e. byte etc
-
-                        var nullUnderlyingType = Nullable.GetUnderlyingType(memberType);
-                        var unboxType = nullUnderlyingType != null && nullUnderlyingType.IsEnum() ? nullUnderlyingType : memberType;
 
                         if (unboxType.IsEnum())
                         {
@@ -2869,19 +2879,9 @@ namespace Dapper
                         else
                         {
                             TypeCode dataTypeCode = TypeExtensions.GetTypeCode(colType), unboxTypeCode = TypeExtensions.GetTypeCode(unboxType);
-                            bool hasTypeHandler;
-                            if ((hasTypeHandler = typeHandlers.ContainsKey(unboxType)) || colType == unboxType || dataTypeCode == unboxTypeCode || dataTypeCode == TypeExtensions.GetTypeCode(nullUnderlyingType))
+                            if (colType == unboxType || dataTypeCode == unboxTypeCode || dataTypeCode == TypeExtensions.GetTypeCode(nullUnderlyingType))
                             {
-                                if (hasTypeHandler)
-                                {
-#pragma warning disable 618
-                                    il.EmitCall(OpCodes.Call, typeof(TypeHandlerCache<>).MakeGenericType(unboxType).GetMethod(nameof(TypeHandlerCache<int>.Parse)), null); // stack is now [target][target][typed-value]
-#pragma warning restore 618
-                                }
-                                else
-                                {
-                                    il.Emit(OpCodes.Unbox_Any, unboxType); // stack is now [target][target][typed-value]
-                                }
+                                il.Emit(OpCodes.Unbox_Any, unboxType); // stack is now [target][target][typed-value]
                             }
                             else
                             {


### PR DESCRIPTION
I gave highest precedence to custom type handlers. This aims to fix #259 by ensuring if a custom type handler is registered the custom type handler is always used instead of any built-in handling.