### PR TITLE
actual/expected in asserts are the wrong way round

### DIFF
--- a/Dapper.Tests/Assert.cs
+++ b/Dapper.Tests/Assert.cs
@@ -4,14 +4,14 @@ namespace Dapper.Tests
 {
     public static class Assert
     {
-        public static void IsEqualTo<T>(this T expected, T actual)
+        public static void IsEqualTo<T>(this T actual, T expected)
         {
             Xunit.Assert.Equal(expected, actual);
         }
 
-        public static void IsSequenceEqualTo<T>(this IEnumerable<T> obj, IEnumerable<T> other)
+        public static void IsSequenceEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected)
         {
-            Xunit.Assert.Equal(obj ?? new T[0], other);
+            Xunit.Assert.Equal(expected, actual ?? new T[0]);
         }
         public static void IsMoreThan(this int a, int b)
         {


### PR DESCRIPTION
All the tests are wrote in the form `actual.IsEqualTo(expected)`. This
made for some odd error messages when a test failed.