### PR TITLE
Add TypeMapperBuilder to use Dapper without setting Attributes on Model classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vs/
 bin/
 obj/
+artifacts/
 /*.user
 _Resharper*
 .hgtags

--- a/Dapper.Contrib/ReflectionHelper.cs
+++ b/Dapper.Contrib/ReflectionHelper.cs
@@ -1,0 +1,31 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Dapper.Contrib
+{
+    public static class ReflectionHelper
+    {
+        public static MemberInfo GetProperty(LambdaExpression lambda)
+        {
+            Expression expr = lambda;
+            for (;;)
+            {
+                switch (expr.NodeType)
+                {
+                    case ExpressionType.Lambda:
+                        expr = ((LambdaExpression)expr).Body;
+                        break;
+                    case ExpressionType.Convert:
+                        expr = ((UnaryExpression)expr).Operand;
+                        break;
+                    case ExpressionType.MemberAccess:
+                        MemberExpression memberExpression = (MemberExpression)expr;
+                        MemberInfo mi = memberExpression.Member;
+                        return mi;
+                    default:
+                        return null;
+                }
+            }
+        }
+    }
+}

--- a/Dapper.Contrib/SqlMapperBuilder.cs
+++ b/Dapper.Contrib/SqlMapperBuilder.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Linq.Expressions;
+using Dapper.Contrib.Extensions;
+
+namespace Dapper.Contrib
+{
+    public static class TypeMappers
+    {
+        public static void Register<T>(TypeMapper<T> mapper) where T : class
+        {
+        }
+
+        public static ITypeMapperBuilder<T> MapType<T>() where T : class
+        {
+            return new CommonTypeMapper<T>();
+        }
+
+        public static void ResetTypeMapping<T>()
+        {
+            var typeHandle = typeof(T).TypeHandle;
+            IEnumerable<PropertyInfo> abc;
+            string tableName;
+            SqlMapperExtensions.InternalComputedProperties.TryRemove(typeHandle, out abc);
+            SqlMapperExtensions.InternalExplicitKeyProperties.TryRemove(typeHandle, out abc);
+            SqlMapperExtensions.InternalKeyProperties.TryRemove(typeHandle, out abc);
+            SqlMapperExtensions.InternalTypeProperties.TryRemove(typeHandle, out abc);
+            SqlMapperExtensions.InternalTypeTableName.TryRemove(typeHandle, out tableName);
+        }
+    }
+
+    public partial interface ITypeMapperBuilder<T> where T : class
+    {
+        ITypeMapperBuilder<T> TableName(string name);
+        IPropertyMapperBuilder<T> For(Expression<Func<T, object>> expression);
+        ITypeMapperBuilder<T> Key(Expression<Func<T, object>> expression);
+    }
+
+    public partial interface IPropertyMapperBuilder<T> where T : class
+    {
+        IPropertyMapperBuilder<T> For(Expression<Func<T, object>> expression);
+        IPropertyMapperBuilder<T> ExplicitKey();
+        IPropertyMapperBuilder<T> NotWritable();
+        IPropertyMapperBuilder<T> Computed();
+    }
+
+    internal class CommonTypeMapper<T> : TypeMapper<T> where T : class
+    {
+    }
+
+    public abstract partial class TypeMapper<T> : ITypeMapperBuilder<T>, IPropertyMapperBuilder<T> where T : class
+    {
+        private static readonly RuntimeTypeHandle TypeHandle = typeof(T).TypeHandle;
+        private PropertyInfo _currentProperty;
+
+        private static void TryAdd(IDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> dic, PropertyInfo property)
+        {
+            if (!dic.ContainsKey(TypeHandle))
+            {
+                dic[TypeHandle] = new List<PropertyInfo>
+                {
+                    property
+                };
+            }
+            else
+            {
+                var list = new List<PropertyInfo>(dic[TypeHandle]) {property};
+                dic[TypeHandle] = list;
+            }
+        }
+
+        private static PropertyInfo GetProperty(Expression<Func<T, object>>  expression)
+        {
+            return ReflectionHelper.GetProperty(expression) as PropertyInfo;
+        }
+
+        public ITypeMapperBuilder<T> TableName(string name)
+        {
+            SqlMapperExtensions.InternalTypeTableName[typeof(T).TypeHandle] = name;
+            return this;            
+        }
+        
+        public IPropertyMapperBuilder<T> For(Expression<Func<T, object>> expression)
+        {
+            _currentProperty = GetProperty(expression);
+            return this;
+        }
+
+        public ITypeMapperBuilder<T> Key(Expression<Func<T, object>> expression)
+        {
+            TryAdd(SqlMapperExtensions.InternalKeyProperties, GetProperty(expression));
+            return this;
+        }
+
+
+        public IPropertyMapperBuilder<T> ExplicitKey()
+        {
+            TryAdd(SqlMapperExtensions.InternalExplicitKeyProperties, _currentProperty);
+            return this;
+        }
+
+        public IPropertyMapperBuilder<T> NotWritable()
+        {
+            var properties = SqlMapperExtensions.InternalTypePropertiesCache(typeof (T));
+            var matchProperty = properties.FirstOrDefault(p => p.Equals(_currentProperty));
+            if (matchProperty != null && properties.Remove(matchProperty))
+            {
+                SqlMapperExtensions.InternalTypeProperties[TypeHandle] = properties;
+            }
+            return this;
+        }
+
+        public IPropertyMapperBuilder<T> Computed()
+        {
+            TryAdd(SqlMapperExtensions.InternalComputedProperties, _currentProperty);
+            return this;
+        }
+    }
+}

--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -686,6 +686,20 @@ namespace Dapper.Contrib.Extensions
     public class ComputedAttribute : Attribute
     {
     }
+
+    public static partial class SqlMapperExtensions
+    {
+        internal static ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> InternalKeyProperties { get { return KeyProperties; } }
+        internal static ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> InternalExplicitKeyProperties { get { return ExplicitKeyProperties; } }
+        internal static ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> InternalComputedProperties { get { return ComputedProperties; } }
+        internal static ConcurrentDictionary<RuntimeTypeHandle, string> InternalTypeTableName { get { return TypeTableName; } }
+        internal static ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> InternalTypeProperties { get { return TypeProperties; } }
+
+        internal static List<PropertyInfo> InternalTypePropertiesCache(Type type)
+        {
+            return TypePropertiesCache(type);
+        }
+    }
 }
 
 public partial interface ISqlAdapter

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -2,9 +2,8 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-
+using Dapper.Contrib;
 using Dapper.Contrib.Extensions;
-
 #if COREFX
 using System.Reflection;
 using IDbConnection = System.Data.Common.DbConnection;
@@ -91,9 +90,25 @@ namespace Dapper.Tests.Contrib
         public int Order { get; set; }
     }
 
+    public class Vehicle
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Computed { get; set; }
+    }
+
+    public class ObjectXWithoutAttribute
+    {
+        public string ObjectXId { get; set; }
+        public string Name { get; set; }
+        public string NotWritable { get; set; }
+    }
+
     public abstract partial class TestSuite
     {
         protected static readonly bool IsAppVeyor = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";
+
+        protected abstract Type SqlClientExceptionType { get; }
 
         public abstract IDbConnection GetConnection();
 
@@ -174,7 +189,36 @@ namespace Dapper.Tests.Contrib
                 o2.IsNull();
             }
         }
-        
+
+        [Fact]
+        public void InsertGetUpdateDeleteWithExplicitKey_UsingBuilder()
+        {
+            TypeMappers
+                .MapType<ObjectXWithoutAttribute>()
+                .TableName("ObjectX")
+                .For(x => x.ObjectXId).ExplicitKey()
+                .For(x => x.NotWritable).NotWritable();
+
+            using (var connection = GetOpenConnection())
+            {
+                var guid = Guid.NewGuid().ToString();
+                var o1 = new ObjectXWithoutAttribute { ObjectXId = guid, Name = "Foo" };
+                var originalxCount = connection.Query<int>("Select Count(*) From ObjectX").First();
+                connection.Insert(o1);
+                var list1 = connection.Query<ObjectXWithoutAttribute>("select * from ObjectX").ToList();
+                list1.Count.IsEqualTo(originalxCount + 1);
+                o1 = connection.Get<ObjectXWithoutAttribute>(guid);
+                o1.ObjectXId.IsEqualTo(guid);
+                o1.Name = "Bar";
+                connection.Update(o1);
+                o1 = connection.Get<ObjectXWithoutAttribute>(guid);
+                o1.Name.IsEqualTo("Bar");
+                connection.Delete(o1);
+                o1 = connection.Get<ObjectXWithoutAttribute>(guid);
+                o1.IsNull();
+            }
+        }
+
         [Fact]
         public void GetAllWithExplicitKey()
         {
@@ -257,6 +301,44 @@ namespace Dapper.Tests.Contrib
                 connection.Get<Car>(id).IsNull();
             }
         }
+
+
+        public class VehicleMapper : TypeMapper<Vehicle>
+        {
+            public VehicleMapper()
+            {
+                this
+                    .TableName("Automobiles")
+                    .For(x => x.Computed).Computed();
+            }
+        }
+
+        [Fact]
+        public void TableName_UsingBuilder()
+        {
+            TypeMappers.Register(new VehicleMapper());
+            using (var connection = GetOpenConnection())
+            {
+                // tests against "Automobiles" table (Table attribute)
+                var id = connection.Insert(new Vehicle { Name = "Prado" });
+                var car = connection.Get<Vehicle>(id);
+                car.IsNotNull();
+                car.Name.IsEqualTo("Prado");
+                connection.Get<Vehicle>(id).Name.IsEqualTo("Prado");
+                connection.Update(new Vehicle { Id = (int)id, Name = "Prado Landcruiser" }).IsEqualTo(true);
+                connection.Get<Vehicle>(id).Name.IsEqualTo("Prado Landcruiser");
+                connection.Delete(new Vehicle { Id = (int)id }).IsEqualTo(true);
+                connection.Get<Vehicle>(id).IsNull();
+            }
+            TypeMappers.ResetTypeMapping<Vehicle>();
+
+            using (var connection = GetOpenConnection())
+            {
+                var ex = Xunit.Assert.Throws(SqlClientExceptionType, () => { connection.Insert(new Vehicle { Name = "Prado" }); });
+                Xunit.Assert.Contains("Vehicles", ex.Message);
+            }
+        }
+
 
         [Fact]
         public void TestSimpleGet()

--- a/Dapper.Tests.Contrib/TestSuite.cs
+++ b/Dapper.Tests.Contrib/TestSuite.cs
@@ -335,7 +335,7 @@ namespace Dapper.Tests.Contrib
             using (var connection = GetOpenConnection())
             {
                 var ex = Xunit.Assert.Throws(SqlClientExceptionType, () => { connection.Insert(new Vehicle { Name = "Prado" }); });
-                Xunit.Assert.Contains("Vehicles", ex.Message);
+                Xunit.Assert.Contains("vehicles", ex.Message.ToLower());
             }
         }
 

--- a/Dapper.Tests.Contrib/TestSuites.cs
+++ b/Dapper.Tests.Contrib/TestSuites.cs
@@ -33,7 +33,7 @@ namespace Dapper.Tests.Contrib
                 ? @"Server=(local)\SQL2014;Database=tempdb;User ID=sa;Password=Password12!"
                 : $"Data Source=.;Initial Catalog={DbName};Integrated Security=True";
         public override IDbConnection GetConnection() => new SqlConnection(ConnectionString);
-
+        protected override Type SqlClientExceptionType { get { return typeof(System.Data.SqlClient.SqlException); } }
         static SqlServerTestSuite()
         {
             using (var connection = new SqlConnection(ConnectionString))
@@ -76,7 +76,7 @@ namespace Dapper.Tests.Contrib
             if (_skip) throw new SkipTestException("Skipping MySQL Tests - no server.");
             return new MySqlConnection(ConnectionString);
         }
-
+        protected override Type SqlClientExceptionType { get { return typeof(MySql.Data.MySqlClient.MySqlException); } }
         private static readonly bool _skip;
 
         static MySqlServerTestSuite()
@@ -127,7 +127,7 @@ namespace Dapper.Tests.Contrib
         const string FileName = "Test.DB.sqlite";
         public static string ConnectionString => $"Filename={FileName};";
         public override IDbConnection GetConnection() => new SqliteConnection(ConnectionString);
-
+        protected override Type SqlClientExceptionType { get { return typeof(System.Data.SQLite.SQLiteException); } }
         static SQLiteTestSuite()
         {
             if (File.Exists(FileName))
@@ -157,7 +157,8 @@ namespace Dapper.Tests.Contrib
         const string FileName = "Test.DB.sdf";
         public static string ConnectionString => $"Data Source={FileName};";
         public override IDbConnection GetConnection() => new SqlCeConnection(ConnectionString);
-            
+        protected override Type SqlClientExceptionType { get { return typeof (System.Data.SqlServerCe.SqlCeException); } }
+
         static SqlCETestSuite()
         {
             if (File.Exists(FileName))

--- a/Dapper.Tests.Contrib/project.json
+++ b/Dapper.Tests.Contrib/project.json
@@ -59,7 +59,8 @@
         "System.Data.Linq": "4.0.0.0",
         "System.Runtime": "4.0.0.0",
         "System.Transactions": "4.0.0.0",
-        "System.Xml": "4.0.0.0"
+        "System.Xml": "4.0.0.0",
+        "System.Threading.Tasks": "4.0.0.0"
       },
       "dependencies": {
         "Microsoft.SqlServer.Compact": "4.0.8876.1",


### PR DESCRIPTION
For classes that we can not change to add attributes
Usages:

``` csharp
public class VehicleMapper : TypeMapper<Vehicle>
{
    public VehicleMapper()
    {
        this
            .TableName("Automobiles")
            .For(x => x.Computed).Computed();
    }
}
TypeMappers.Register(new VehicleMapper());
```

OR

``` csharp
TypeMappers
    .MapType<ObjectXWithoutAttribute>()
    .TableName("ObjectX")
    .For(x => x.ObjectXId).ExplicitKey()
    .For(x => x.NotWritable).NotWritable();
```
