### PR TITLE
Allow custom TypeHandlers for standard types

### DIFF
--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -370,6 +370,10 @@ namespace Dapper
             {
                 type = Enum.GetUnderlyingType(type);
             }
+            if (typeHandlers.TryGetValue(type, out handler))
+            {
+                return DbType.Object;
+            }
             if (typeMap.TryGetValue(type, out dbType))
             {
                 return dbType;
@@ -377,10 +381,6 @@ namespace Dapper
             if (type.FullName == LinqBinary)
             {
                 return DbType.Binary;
-            }
-            if (typeHandlers.TryGetValue(type, out handler))
-            {
-                return DbType.Object;
             }
             if (typeof(IEnumerable).IsAssignableFrom(type))
             {


### PR DESCRIPTION
Given:
```c#
public class DateTimeOffsetHandler : SqlMapper.TypeHandler<DateTimeOffset>
{
  public override void SetValue(IDbDataParameter parameter, DateTimeOffset value)
  {
    ...
  }

  public override DateTimeOffset Parse(object value)
  {
    ...
  }
}

...

SqlMapper.AddTypeHandler(new DateTimeOffsetHandler());
```

In the original code:
* When reading from the DB, `Parse` is called as expected.
* When writing to the DB, `SetValue` is skipped because the subject of our `TypeHandler` (`DateTimeOffset` in this case) is included the `typeMap` and that short-circuits the type lookup.

By swapping the two checks we allow type handlers for standard .NET types which is useful to overcome driver limitations (such as MONO's [`System.Data.SqlClient` DateTimeOffset support](https://bugzilla.xamarin.com/show_bug.cgi?id=39116)).

