### PR TITLE
Trim package dependencies

### DIFF
--- a/Dapper/project.json
+++ b/Dapper/project.json
@@ -55,14 +55,24 @@
         "define": [ "ASYNC", "COREFX" ]
       },
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
+        "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
+        "Microsoft.NETCore.Runtime": "1.0.2-rc2-24027",
+        "System.Collections": "4.0.11-rc2-24027",
+        "System.Collections.Concurrent": "4.0.12-rc2-24027",
+        "System.Collections.NonGeneric": "4.0.1-rc2-24027",
         "System.Data.SqlClient": "4.1.0-rc2-24027",
         "System.Dynamic.Runtime": "4.0.11-rc2-24027",
+        "System.Linq": "4.1.0-rc2-24027",
         "System.Reflection.Emit": "4.0.1-rc2-24027",
         "System.Reflection.Emit.Lightweight": "4.0.1-rc2-24027",
-        "System.Xml.XmlDocument": "4.0.1-rc2-24027",
-        "System.Collections.NonGeneric": "4.0.1-rc2-24027",
-        "System.Reflection.TypeExtensions": "4.1.0-rc2-24027"
+        "System.Reflection.Extensions": "4.0.1-rc2-24027",
+        "System.Reflection.TypeExtensions": "4.1.0-rc2-24027",
+        "System.Runtime.Extensions": "4.1.0-rc2-24027",
+        "System.Runtime.InteropServices": "4.1.0-rc2-24027",
+        "System.Text.RegularExpressions": "4.0.12-rc2-24027",
+        "System.Threading": "4.0.11-rc2-24027",
+        "System.Xml.XDocument": "4.0.11-rc2-24027",
+        "System.Xml.XmlDocument": "4.0.1-rc2-24027"
       }
     }
   }


### PR DESCRIPTION
Trimmed the package dependencies by not referencing `NETStandard.Libary` and the kitchen sink but in stead reference each required package individually. This reduces the package footprint of Dapper.

Reference: https://dotnet.github.io/docs/scenarios/library-authoring/trimming.html

--

I'm not sure if you are interested in this. But since Dapper is all about performance, I figured I give it a shot.