### PR TITLE
fix invalid condition used in QueryFirst and QuerySingle

### DIFF
--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -272,7 +272,7 @@ namespace Dapper
                 try
                 {
                     if (wasClosed) await ((DbConnection)cnn).OpenAsync(cancel).ConfigureAwait(false);
-                    reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, (row & Row.Single) != 0
+                    reader = await ExecuteReaderWithFlagsFallbackAsync(cmd, wasClosed, (row & Row.Single) == 0
                     ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
                     : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow, cancel).ConfigureAwait(false);
 

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -1024,7 +1024,7 @@ namespace Dapper
                 cmd = command.SetupCommand(cnn, info.ParamReader);
 
                 if (wasClosed) cnn.Open();
-                reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, (row & Row.Single) != 0
+                reader = ExecuteReaderWithFlagsFallback(cmd, wasClosed, (row & Row.Single) == 0
                     ? CommandBehavior.SequentialAccess | CommandBehavior.SingleResult // need to allow multiple rows, to check fail condition
                     : CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow);
                 wasClosed = false; // *if* the connection was closed and we got this far, then we now have a reader


### PR DESCRIPTION
I think `(row & Row.Single) != 0` is row is not Row.First so should swap condition.

By the way, in MySQL if use CommandBehavior.SingleRow, MySQL Connector execute `SET SQL_SELECT_LIMIT=1` on each query. (at command.cs - HandleCommandBeehaviors)
It causes performance issue so I need disable command behavior option...