### PR TITLE
Fix #573 - OrWhere yielding AndWhere statement

### DIFF
--- a/Dapper.SqlBuilder/SqlBuilder.cs
+++ b/Dapper.SqlBuilder/SqlBuilder.cs
@@ -143,7 +143,7 @@ namespace Dapper
         
         public SqlBuilder OrWhere(string sql, dynamic parameters = null)
         {
-            AddClause("where", sql, parameters, " AND ", "WHERE ", "\n", true);
+            AddClause("where", sql, parameters, " OR ", "WHERE ", "\n", true);
             return this;
         }
         


### PR DESCRIPTION
Fixes #573 where calling the SqlBuilder.OrWhere statement was actually yielding an 'AND WHERE' string. 