### PR TITLE
Add CommandDefinitions versions for async Query API

### DIFF
--- a/Dapper.Tests/Tests.Async.cs
+++ b/Dapper.Tests/Tests.Async.cs
@@ -21,6 +21,34 @@ namespace Dapper.Tests
         }
 
         [Fact]
+        public async Task TestBasicStringUsageQueryFirstAsync()
+        {
+            var str = await connection.QueryFirstAsync<string>(new CommandDefinition("select 'abc' as [Value] union all select @txt", new {txt = "def"}));
+            str.IsEqualTo("abc");
+        }
+
+        [Fact]
+        public async Task TestBasicStringUsageQueryFirstOrDefaultAsync()
+        {
+            var str = await connection.QueryFirstOrDefaultAsync<string>(new CommandDefinition("select null as [Value]"));
+            str.IsNull();
+        }
+
+        [Fact]
+        public async Task TestBasicStringUsageQuerySingleAsync()
+        {
+            var str = await connection.QuerySingleAsync<string>(new CommandDefinition("select 'abc' as [Value] union all select @txt", new {txt = "def"}));
+            str.IsEqualTo("abc");
+        }
+
+        [Fact]
+        public async Task TestBasicStringUsageQuerySingleOrDefaultAsync()
+        {
+            var str = await connection.QuerySingleAsync<string>(new CommandDefinition("select null as [Value]"));
+            str.IsNull();
+        }
+
+        [Fact]
         public async Task TestBasicStringUsageAsyncNonBuffered()
         {
             var query = await connection.QueryAsync<string>(new CommandDefinition("select 'abc' as [Value] union all select @txt", new { txt = "def" }, flags: CommandFlags.None));

--- a/Dapper.Tests/Tests.Async.cs
+++ b/Dapper.Tests/Tests.Async.cs
@@ -30,14 +30,14 @@ namespace Dapper.Tests
         [Fact]
         public async Task TestBasicStringUsageQueryFirstOrDefaultAsync()
         {
-            var str = await connection.QueryFirstOrDefaultAsync<string>(new CommandDefinition("select null as [Value]"));
+            var str = await connection.QueryFirstOrDefaultAsync<string>(new CommandDefinition("select null as [Value] union all select @txt", new {txt = "def"}));
             str.IsNull();
         }
 
         [Fact]
         public async Task TestBasicStringUsageQuerySingleAsync()
         {
-            var str = await connection.QuerySingleAsync<string>(new CommandDefinition("select 'abc' as [Value] union all select @txt", new {txt = "def"}));
+            var str = await connection.QuerySingleAsync<string>(new CommandDefinition("select 'abc' as [Value]"));
             str.IsEqualTo("abc");
         }
 

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -168,9 +168,23 @@ namespace Dapper
         /// <summary>
         /// Execute a single-row query asynchronously using .NET 4.5 Task.
         /// </summary>
+        public static Task<T> QueryFirstAsync<T>(this IDbConnection cnn, CommandDefinition command)
+        {
+            return QueryRowAsync<T>(cnn, Row.First, typeof(T), command);
+        }
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5 Task.
+        /// </summary>
         public static Task<object> QueryFirstOrDefaultAsync(this IDbConnection cnn, Type type, CommandDefinition command)
         {
             return QueryRowAsync<object>(cnn, Row.FirstOrDefault, type, command);
+        }
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5 Task.
+        /// </summary>
+        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDbConnection cnn, CommandDefinition command)
+        {
+            return QueryRowAsync<T>(cnn, Row.FirstOrDefault, typeof(T), command);
         }
         /// <summary>
         /// Execute a single-row query asynchronously using .NET 4.5 Task.
@@ -182,11 +196,24 @@ namespace Dapper
         /// <summary>
         /// Execute a single-row query asynchronously using .NET 4.5 Task.
         /// </summary>
+        public static Task<T> QuerySingleAsync<T>(this IDbConnection cnn, CommandDefinition command)
+        {
+            return QueryRowAsync<T>(cnn, Row.Single, typeof(T), command);
+        }
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5 Task.
+        /// </summary>
         public static Task<object> QuerySingleOrDefaultAsync(this IDbConnection cnn, Type type, CommandDefinition command)
         {
             return QueryRowAsync<object>(cnn, Row.SingleOrDefault, type, command);
         }
-
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5 Task.
+        /// </summary>
+        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDbConnection cnn, CommandDefinition command)
+        {
+            return QueryRowAsync<T>(cnn, Row.SingleOrDefault, typeof(T), command);
+        }
 
         private static Task<DbDataReader> ExecuteReaderWithFlagsFallbackAsync(DbCommand cmd, bool wasClosed, CommandBehavior behavior, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Trivial ports of the non-typesafe versions to the typesafe versions of the async query api.
Solves issue #484 