### PR TITLE
Make CommandBehavior optimizations more configurable

### DIFF
--- a/Dapper.Tests/Tests.Async.cs
+++ b/Dapper.Tests/Tests.Async.cs
@@ -771,6 +771,19 @@ SET @AddressPersonId = @PersonId", p))
                 reader.Read().IsFalse();
             }
         }
+
+        [Fact]
+        public async Task Issue563_QueryAsyncShouldThrowException()
+        {
+            try
+            {
+                var data = (await connection.QueryAsync<int>("select 1 union all select 2")).ToList();
+                Assert.Fail();
+            }catch(SqlException ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+        }
     }
 }
 #endif

--- a/Dapper.Tests/Tests.Async.cs
+++ b/Dapper.Tests/Tests.Async.cs
@@ -777,12 +777,10 @@ SET @AddressPersonId = @PersonId", p))
         {
             try
             {
-                var data = (await connection.QueryAsync<int>("select 1 union all select 2")).ToList();
+                var data = (await connection.QueryAsync<int>("select 1 union all select 2; RAISERROR('after select', 16, 1);")).ToList();
                 Assert.Fail();
-            }catch(SqlException ex)
-            {
-                Console.WriteLine(ex.Message);
             }
+            catch (SqlException ex) when (ex.Message == "after select") { }
         }
     }
 }

--- a/Dapper/SqlMapper.Async.cs
+++ b/Dapper/SqlMapper.Async.cs
@@ -218,7 +218,7 @@ namespace Dapper
         private static Task<DbDataReader> ExecuteReaderWithFlagsFallbackAsync(DbCommand cmd, bool wasClosed, CommandBehavior behavior, CancellationToken cancellationToken)
         {
             var task = cmd.ExecuteReaderAsync(GetBehavior(wasClosed, behavior), cancellationToken);
-            if (task.Status == TaskStatus.Faulted && DisableCommandBehaviorOptimizations(behavior, task.Exception.InnerException))
+            if (task.Status == TaskStatus.Faulted && Settings.DisableCommandBehaviorOptimizations(behavior, task.Exception.InnerException))
             { // we can retry; this time it will have different flags
                 task = cmd.ExecuteReaderAsync(GetBehavior(wasClosed, behavior), cancellationToken);
             }

--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -21,6 +21,7 @@ namespace Dapper
             /// <summary>
             /// Gets or sets whether dapper should use the CommandBehavior.SingleResult optimization
             /// </summary>
+            /// <remarks>Note that a consequence of enabling this option is that errors that happen <b>after</b> the first select may not be reported</remarks>
             public static bool UseSingleResultOptimization
             {
                 get { return (AllowedCommandBehaviors & CommandBehavior.SingleResult) != 0; }
@@ -29,6 +30,7 @@ namespace Dapper
             /// <summary>
             /// Gets or sets whether dapper should use the CommandBehavior.SingleRow optimization
             /// </summary>
+            /// <remarks>Note that on some DB providers this optimization can have adverse performance impact</remarks>
             public static bool UseSingleRowOptimization
             {
                 get { return (AllowedCommandBehaviors & CommandBehavior.SingleRow) != 0; }

--- a/Dapper/SqlMapper.Settings.cs
+++ b/Dapper/SqlMapper.Settings.cs
@@ -19,7 +19,7 @@ namespace Dapper
                 else AllowedCommandBehaviors &= ~behavior;
             }
             /// <summary>
-            /// Gets or sets whether dapper should use the CommandBehavior.SingleResult optimization
+            /// Gets or sets whether Dapper should use the CommandBehavior.SingleResult optimization
             /// </summary>
             /// <remarks>Note that a consequence of enabling this option is that errors that happen <b>after</b> the first select may not be reported</remarks>
             public static bool UseSingleResultOptimization
@@ -28,7 +28,7 @@ namespace Dapper
                 set { SetAllowedCommandBehaviors(CommandBehavior.SingleResult, value); }
             }
             /// <summary>
-            /// Gets or sets whether dapper should use the CommandBehavior.SingleRow optimization
+            /// Gets or sets whether Dapper should use the CommandBehavior.SingleRow optimization
             /// </summary>
             /// <remarks>Note that on some DB providers this optimization can have adverse performance impact</remarks>
             public static bool UseSingleRowOptimization

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -122,7 +122,7 @@ namespace Dapper
         }
 
         /// <summary>
-        /// Return a count of all the cached queries by dapper
+        /// Return a count of all the cached queries by Dapper
         /// </summary>
         /// <returns></returns>
         public static int GetCachedSQLCount()
@@ -131,7 +131,7 @@ namespace Dapper
         }
 
         /// <summary>
-        /// Return a list of all the queries cached by dapper
+        /// Return a list of all the queries cached by Dapper
         /// </summary>
         /// <param name="ignoreHitCountAbove"></param>
         /// <returns></returns>

--- a/Dapper/SqlMapper.cs
+++ b/Dapper/SqlMapper.cs
@@ -236,8 +236,6 @@ namespace Dapper
             AddTypeHandlerImpl(typeof(XmlDocument), new XmlDocumentHandler(), clone);
             AddTypeHandlerImpl(typeof(XDocument), new XDocumentHandler(), clone);
             AddTypeHandlerImpl(typeof(XElement), new XElementHandler(), clone);
-
-            allowedCommandBehaviors = DefaultAllowedCommandBehaviors;
         }
 #if !COREFX
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -912,7 +910,7 @@ namespace Dapper
             }
             catch (ArgumentException ex)
             { // thanks, Sqlite!
-                if (DisableCommandBehaviorOptimizations(behavior, ex))
+                if (Settings.DisableCommandBehaviorOptimizations(behavior, ex))
                 {
                     // we can retry; this time it will have different flags
                     return cmd.ExecuteReader(GetBehavior(wasClosed, behavior));
@@ -1324,25 +1322,10 @@ namespace Dapper
                 }
             }
         }
-        const CommandBehavior DefaultAllowedCommandBehaviors = ~((CommandBehavior)0);
-        static CommandBehavior allowedCommandBehaviors = DefaultAllowedCommandBehaviors;
-        private static bool DisableCommandBehaviorOptimizations(CommandBehavior behavior, Exception ex)
-        {
-            if(allowedCommandBehaviors == DefaultAllowedCommandBehaviors
-                && (behavior & (CommandBehavior.SingleResult | CommandBehavior.SingleRow)) != 0)
-            {
-                if (ex.Message.Contains(nameof(CommandBehavior.SingleResult))
-                    || ex.Message.Contains(nameof(CommandBehavior.SingleRow)))
-                { // some providers just just allow these, so: try again without them and stop issuing them
-                    allowedCommandBehaviors = ~(CommandBehavior.SingleResult | CommandBehavior.SingleRow);
-                    return true;
-                }
-            }
-            return false;
-        }
+
         private static CommandBehavior GetBehavior(bool close, CommandBehavior @default)
         {
-            return (close ? (@default | CommandBehavior.CloseConnection) : @default) & allowedCommandBehaviors;
+            return (close ? (@default | CommandBehavior.CloseConnection) : @default) & Settings.AllowedCommandBehaviors;
         }
         static IEnumerable<TReturn> MultiMapImpl<TReturn>(this IDbConnection cnn, CommandDefinition command, Type[] types, Func<object[], TReturn> map, string splitOn, IDataReader reader, Identity identity, bool finalize)
         {


### PR DESCRIPTION
Default to SingleRow=allowed, SingleResult=disallowed - but expose options; this fixes issues like #563 automatically, and allows the performance aspect  of #554 to be fixed via a global setting