### PR TITLE
MatchNamesWithUnderscores for Insert and Update

### DIFF
--- a/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/Dapper.Contrib/SqlMapperExtensions.cs
@@ -17,6 +17,15 @@ using System.Threading;
 
 namespace Dapper.Contrib.Extensions
 {
+    public static class Utility
+    {
+        public static string PascalCaseToSnakeCase(string pascalCaseString)
+        {
+            return string.Concat(pascalCaseString.Select((character, index)
+                => index > 0 && char.IsUpper(character) ? "_" + character.ToString() : character.ToString())).ToLower();
+        }
+    }
+
     public static partial class SqlMapperExtensions
     {
         // ReSharper disable once MemberCanBePrivate.Global
@@ -316,7 +325,15 @@ namespace Dapper.Contrib.Extensions
             for (var i = 0; i < allPropertiesExceptKeyAndComputed.Count; i++)
             {
                 var property = allPropertiesExceptKeyAndComputed.ElementAt(i);
-                adapter.AppendColumnName(sbColumnList, property.Name);  //fix for issue #336
+
+                var columnName = property.Name;
+
+                if (DefaultTypeMap.MatchNamesWithUnderscores)
+                {
+                    columnName = Utility.PascalCaseToSnakeCase(columnName);
+                }
+
+                adapter.AppendColumnName(sbColumnList, columnName);  //fix for issue #336
                 if (i < allPropertiesExceptKeyAndComputed.Count - 1)
                     sbColumnList.Append(", ");
             }
@@ -691,8 +708,8 @@ public partial interface ISqlAdapter
     int Insert(IDbConnection connection, IDbTransaction transaction, int? commandTimeout, string tableName, string columnList, string parameterList, IEnumerable<PropertyInfo> keyProperties, object entityToInsert);
     
     //new methods for issue #336
-    void AppendColumnName(StringBuilder sb, string columnName);
-    void AppendColumnNameEqualsValue(StringBuilder sb, string columnName);
+    void AppendColumnName(StringBuilder sb, string propertyName);
+    void AppendColumnNameEqualsValue(StringBuilder sb, string propertyName);
 }
 
 public partial class SqlServerAdapter : ISqlAdapter
@@ -715,14 +732,28 @@ public partial class SqlServerAdapter : ISqlAdapter
         return id;
     }
 
-    public void AppendColumnName(StringBuilder sb, string columnName)
+    public void AppendColumnName(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+        
         sb.AppendFormat("[{0}]", columnName);
     }
 
-    public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
+    public void AppendColumnNameEqualsValue(StringBuilder sb, string propertyName)
     {
-        sb.AppendFormat("[{0}] = @{1}", columnName, columnName);
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
+        sb.AppendFormat("[{0}] = @{1}", columnName, propertyName);
     }
 }
 
@@ -746,13 +777,27 @@ public partial class SqlCeServerAdapter : ISqlAdapter
         return id;
     }
 
-    public void AppendColumnName(StringBuilder sb, string columnName)
+    public void AppendColumnName(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("[{0}]", columnName);
     }
 
-    public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
+    public void AppendColumnNameEqualsValue(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("[{0}] = @{1}", columnName, columnName);
     }
 }
@@ -776,13 +821,27 @@ public partial class MySqlAdapter : ISqlAdapter
         return Convert.ToInt32(id);
     }
 
-    public void AppendColumnName(StringBuilder sb, string columnName)
+    public void AppendColumnName(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("`{0}`", columnName);
     }
 
-    public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
+    public void AppendColumnNameEqualsValue(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("`{0}` = @{1}", columnName, columnName);
     }
 }
@@ -826,13 +885,27 @@ public partial class PostgresAdapter : ISqlAdapter
         return id;
     }
 
-    public void AppendColumnName(StringBuilder sb, string columnName)
+    public void AppendColumnName(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("\"{0}\"", columnName);
     }
 
-    public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
+    public void AppendColumnNameEqualsValue(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("\"{0}\" = @{1}", columnName, columnName);
     }
 }
@@ -854,13 +927,27 @@ public partial class SQLiteAdapter : ISqlAdapter
         return id;
     }
 
-    public void AppendColumnName(StringBuilder sb, string columnName)
+    public void AppendColumnName(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("\"{0}\"", columnName);
     }
 
-    public void AppendColumnNameEqualsValue(StringBuilder sb, string columnName)
+    public void AppendColumnNameEqualsValue(StringBuilder sb, string propertyName)
     {
+        var columnName = propertyName;
+
+        if (DefaultTypeMap.MatchNamesWithUnderscores)
+        {
+            columnName = Dapper.Contrib.Extensions.Utility.PascalCaseToSnakeCase(propertyName);
+        }
+
         sb.AppendFormat("\"{0}\" = @{1}", columnName, columnName);
     }
 }


### PR DESCRIPTION
Insert and Update now take in consideration the DefaultTypeMap.MatchNamesWithUnderscores option and follow the model properties' PascalCase to table columns' snake_case convention. #515 
