### PR TITLE
GridReader.IsConsumed wouldn't be true

### DIFF
--- a/Dapper/SqlMapper.GridReader.cs
+++ b/Dapper/SqlMapper.GridReader.cs
@@ -215,6 +215,9 @@ namespace Dapper
                     typeof(TSixth),
                     typeof(TSeventh)
                 }, gridIndex);
+
+                IsConsumed = true;
+
                 try
                 {
                     foreach (var r in MultiMapImpl<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(null, default(CommandDefinition), func, splitOn, reader, identity, false))


### PR DESCRIPTION
I found that GridReader.IsConsumed wouldn't be true when I use Read method with splitOn parameter. Here is a screenshot of this issue.

![2016-09-21](https://cloud.githubusercontent.com/assets/1000655/18711460/09bffb7e-8045-11e6-9b8f-079dd31771d9.png)

So I fixed this. Here is the expected behavior.

![2016-09-21 2](https://cloud.githubusercontent.com/assets/1000655/18711589/a717d6f8-8045-11e6-9e84-44eef016ad04.png)
